### PR TITLE
Add dry-run / preview mode (+3 more)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -74,3 +74,10 @@ CRYYER_REPO=owner/repo
 
 # Set automatically by GitHub Actions — do not set manually
 # GITHUB_REPOSITORY=owner/repo
+
+# =============================================================================
+# Dry-run / Preview Mode
+# =============================================================================
+
+# Set to "true" to print email drafts to stdout instead of sending or creating issues
+# DRY_RUN=true

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,37 @@
+---
+name: Bug report
+about: Report a bug or unexpected behavior
+labels: bug
+---
+
+## Description
+
+A clear and concise description of the bug.
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Expected behavior
+
+What you expected to happen.
+
+## Actual behavior
+
+What actually happened. Include any error messages or stack traces.
+
+## Environment
+
+- OS:
+- Node.js version (`node --version`):
+- pnpm version (`pnpm --version`):
+- Cryyer version:
+- LLM provider (`LLM_PROVIDER`):
+- Subscriber store (`SUBSCRIBER_STORE`):
+- Entry point used (draft, send-on-close, index, mcp):
+
+## Additional context
+
+Any other context, screenshots, or logs that might help diagnose the issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: Feature request
+about: Suggest a new feature or improvement
+labels: enhancement
+---
+
+## Problem
+
+A clear description of the problem or limitation this feature would address.
+Example: "I have to manually do X every time because..."
+
+## Proposed solution
+
+A clear description of what you want to happen.
+
+## Alternatives considered
+
+Any alternative solutions or features you've considered, and why they don't fully address the problem.
+
+## Additional context
+
+Any other context, mockups, or examples that would help clarify the request.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+## Description
+
+A brief description of what this PR does and why.
+
+Closes #
+
+## Changes
+
+-
+-
+
+## Testing
+
+- [ ] Tests added or updated for new behavior
+- [ ] All existing tests pass (`pnpm test`)
+- [ ] Lint and type-check pass (`pnpm lint && pnpm typecheck`)
+
+## Checklist
+
+- [ ] The change is backward-compatible (or breaking changes are documented)
+- [ ] Documentation updated (README, CLAUDE.md) if needed
+- [ ] No secrets or private configs committed

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "./mcp": "./dist/mcp.js"
   },
   "bin": {
-    "cryyer-mcp": "./dist/mcp.js"
+    "cryyer-mcp": "./dist/mcp.js",
+    "cryyer": "./dist/init.js"
   },
   "scripts": {
     "build": "tsc",
@@ -48,7 +49,9 @@
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:watch": "vitest",
-    "mcp": "node dist/mcp.js"
+    "mcp": "node dist/mcp.js",
+    "check": "node dist/check.js",
+    "init": "node dist/init.js"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.78.0",

--- a/src/__tests__/check.test.ts
+++ b/src/__tests__/check.test.ts
@@ -1,0 +1,270 @@
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
+import type { Mock } from 'vitest';
+
+vi.mock('../config.js', () => ({ loadProducts: vi.fn() }));
+vi.mock('octokit', () => ({ Octokit: vi.fn(function OctokitMock() {}) }));
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: vi.fn(),
+}));
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>();
+  return { ...actual, existsSync: vi.fn() };
+});
+
+import { checkProducts, checkGitHub, checkLLMProvider, checkSubscriberStore, checkEmailConfig } from '../check.js';
+import { loadProducts } from '../config.js';
+import { Octokit } from 'octokit';
+import { createClient } from '@supabase/supabase-js';
+import { existsSync } from 'fs';
+
+describe('checkProducts', () => {
+  beforeEach(() => {
+    (existsSync as Mock).mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('passes when all products are valid', async () => {
+    (loadProducts as Mock).mockReturnValue([
+      {
+        id: 'my-app',
+        name: 'My App',
+        voice: 'Friendly',
+        repo: 'owner/my-app',
+        emailSubjectTemplate: '{{weekOf}} Update',
+      },
+    ]);
+    const result = await checkProducts('/fake/products');
+    expect(result.passed).toBe(true);
+    expect(result.message).toContain('1 product');
+  });
+
+  it('fails when products directory does not exist', async () => {
+    (existsSync as Mock).mockReturnValue(false);
+    const result = await checkProducts('/nonexistent');
+    expect(result.passed).toBe(false);
+    expect(result.message).toContain('not found');
+  });
+
+  it('fails when no YAML files are found', async () => {
+    (loadProducts as Mock).mockReturnValue([]);
+    const result = await checkProducts('/fake/products');
+    expect(result.passed).toBe(false);
+    expect(result.message).toContain('No product YAML');
+  });
+
+  it('fails when a product is missing required fields', async () => {
+    (loadProducts as Mock).mockReturnValue([{ id: 'test', name: 'Test' }]);
+    const result = await checkProducts('/fake/products');
+    expect(result.passed).toBe(false);
+    expect(result.message).toContain('voice');
+  });
+
+  it('fails when loadProducts throws', async () => {
+    (loadProducts as Mock).mockImplementation(() => {
+      throw new Error('YAML parse error');
+    });
+    const result = await checkProducts('/fake/products');
+    expect(result.passed).toBe(false);
+    expect(result.message).toContain('YAML parse error');
+  });
+});
+
+describe('checkGitHub', () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    vi.clearAllMocks();
+  });
+
+  it('fails when GITHUB_TOKEN is not set', async () => {
+    delete process.env['GITHUB_TOKEN'];
+    const result = await checkGitHub();
+    expect(result.passed).toBe(false);
+    expect(result.message).toContain('GITHUB_TOKEN');
+  });
+
+  it('passes when GitHub authentication succeeds', async () => {
+    process.env['GITHUB_TOKEN'] = 'valid-token';
+    const mockOctokit = {
+      rest: {
+        users: {
+          getAuthenticated: vi.fn().mockResolvedValue({ data: { login: 'octocat' } }),
+        },
+      },
+    };
+    (Octokit as unknown as Mock).mockImplementation(function () {
+      return mockOctokit;
+    });
+    const result = await checkGitHub();
+    expect(result.passed).toBe(true);
+    expect(result.message).toContain('octocat');
+  });
+
+  it('fails when GitHub authentication fails', async () => {
+    process.env['GITHUB_TOKEN'] = 'bad-token';
+    const mockOctokit = {
+      rest: {
+        users: {
+          getAuthenticated: vi.fn().mockRejectedValue(new Error('Unauthorized')),
+        },
+      },
+    };
+    (Octokit as unknown as Mock).mockImplementation(function () {
+      return mockOctokit;
+    });
+    const result = await checkGitHub();
+    expect(result.passed).toBe(false);
+    expect(result.message).toContain('Unauthorized');
+  });
+});
+
+describe('checkLLMProvider', () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('passes when ANTHROPIC_API_KEY is set (default provider)', () => {
+    delete process.env['LLM_PROVIDER'];
+    process.env['ANTHROPIC_API_KEY'] = 'test-key';
+    const result = checkLLMProvider();
+    expect(result.passed).toBe(true);
+    expect(result.message).toContain('anthropic');
+  });
+
+  it('fails when ANTHROPIC_API_KEY is missing', () => {
+    delete process.env['LLM_PROVIDER'];
+    delete process.env['ANTHROPIC_API_KEY'];
+    const result = checkLLMProvider();
+    expect(result.passed).toBe(false);
+    expect(result.message).toContain('ANTHROPIC_API_KEY');
+  });
+
+  it('passes when OPENAI_API_KEY is set with openai provider', () => {
+    process.env['LLM_PROVIDER'] = 'openai';
+    process.env['OPENAI_API_KEY'] = 'sk-test';
+    const result = checkLLMProvider();
+    expect(result.passed).toBe(true);
+    expect(result.message).toContain('openai');
+  });
+
+  it('fails for unknown provider', () => {
+    process.env['LLM_PROVIDER'] = 'unknown-llm';
+    const result = checkLLMProvider();
+    expect(result.passed).toBe(false);
+    expect(result.message).toContain('unknown-llm');
+  });
+});
+
+describe('checkSubscriberStore', () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    vi.clearAllMocks();
+  });
+
+  it('fails when supabase vars are missing (default store)', async () => {
+    delete process.env['SUBSCRIBER_STORE'];
+    delete process.env['SUPABASE_URL'];
+    delete process.env['SUPABASE_SERVICE_KEY'];
+    const result = await checkSubscriberStore();
+    expect(result.passed).toBe(false);
+    expect(result.message).toContain('SUPABASE_URL');
+  });
+
+  it('passes when supabase connection succeeds', async () => {
+    process.env['SUBSCRIBER_STORE'] = 'supabase';
+    process.env['SUPABASE_URL'] = 'https://example.supabase.co';
+    process.env['SUPABASE_SERVICE_KEY'] = 'service-key';
+    const mockDb = {
+      from: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue({ error: null }),
+        }),
+      }),
+    };
+    (createClient as Mock).mockReturnValue(mockDb);
+    const result = await checkSubscriberStore();
+    expect(result.passed).toBe(true);
+    expect(result.message).toContain('verified');
+  });
+
+  it('fails when supabase connection returns error', async () => {
+    process.env['SUBSCRIBER_STORE'] = 'supabase';
+    process.env['SUPABASE_URL'] = 'https://example.supabase.co';
+    process.env['SUPABASE_SERVICE_KEY'] = 'bad-key';
+    const mockDb = {
+      from: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue({ error: new Error('connection refused') }),
+        }),
+      }),
+    };
+    (createClient as Mock).mockReturnValue(mockDb);
+    const result = await checkSubscriberStore();
+    expect(result.passed).toBe(false);
+    expect(result.message).toContain('connection refused');
+  });
+
+  it('passes when json store file exists', async () => {
+    process.env['SUBSCRIBER_STORE'] = 'json';
+    process.env['SUBSCRIBERS_JSON_PATH'] = './subscribers.json';
+    (existsSync as Mock).mockReturnValue(true);
+    const result = await checkSubscriberStore();
+    expect(result.passed).toBe(true);
+    expect(result.message).toContain('JSON file found');
+  });
+
+  it('fails when json store file does not exist', async () => {
+    process.env['SUBSCRIBER_STORE'] = 'json';
+    process.env['SUBSCRIBERS_JSON_PATH'] = './subscribers.json';
+    (existsSync as Mock).mockReturnValue(false);
+    const result = await checkSubscriberStore();
+    expect(result.passed).toBe(false);
+    expect(result.message).toContain('not found');
+  });
+
+  it('fails for unknown store type', async () => {
+    process.env['SUBSCRIBER_STORE'] = 'unknown-store';
+    const result = await checkSubscriberStore();
+    expect(result.passed).toBe(false);
+    expect(result.message).toContain('unknown-store');
+  });
+});
+
+describe('checkEmailConfig', () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('passes when both vars are set', () => {
+    process.env['RESEND_API_KEY'] = 're_test';
+    process.env['FROM_EMAIL'] = 'updates@example.com';
+    const result = checkEmailConfig();
+    expect(result.passed).toBe(true);
+  });
+
+  it('fails when RESEND_API_KEY is missing', () => {
+    delete process.env['RESEND_API_KEY'];
+    process.env['FROM_EMAIL'] = 'updates@example.com';
+    const result = checkEmailConfig();
+    expect(result.passed).toBe(false);
+    expect(result.message).toContain('RESEND_API_KEY');
+  });
+
+  it('fails when FROM_EMAIL is missing', () => {
+    process.env['RESEND_API_KEY'] = 're_test';
+    delete process.env['FROM_EMAIL'];
+    const result = checkEmailConfig();
+    expect(result.passed).toBe(false);
+    expect(result.message).toContain('FROM_EMAIL');
+  });
+});

--- a/src/__tests__/draft.test.ts
+++ b/src/__tests__/draft.test.ts
@@ -19,7 +19,7 @@ vi.mock('octokit', () => ({
   Octokit: vi.fn(function OctokitMock() {}),
 }));
 
-import { getWeekOf, requireEnv, ensureLabel, main } from '../draft.js';
+import { getWeekOf, requireEnv, ensureLabel, isDryRun, main } from '../draft.js';
 import { loadProducts } from '../config.js';
 import { gatherWeeklyActivity } from '../gather.js';
 import { generateEmailDraft } from '../summarize.js';
@@ -242,5 +242,106 @@ describe('main orchestration', () => {
   it('throws when CRYYER_REPO is missing', async () => {
     delete process.env['CRYYER_REPO'];
     await expect(main()).rejects.toThrow('Missing required environment variable: CRYYER_REPO');
+  });
+});
+
+describe('isDryRun', () => {
+  const originalEnv = { ...process.env };
+  const originalArgv = [...process.argv];
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    process.argv = [...originalArgv];
+  });
+
+  it('returns false by default', () => {
+    delete process.env['DRY_RUN'];
+    process.argv = process.argv.filter((a) => a !== '--dry-run');
+    expect(isDryRun()).toBe(false);
+  });
+
+  it('returns true when DRY_RUN=true', () => {
+    process.env['DRY_RUN'] = 'true';
+    expect(isDryRun()).toBe(true);
+  });
+
+  it('returns true when --dry-run flag is passed', () => {
+    delete process.env['DRY_RUN'];
+    process.argv = [...process.argv, '--dry-run'];
+    expect(isDryRun()).toBe(true);
+  });
+});
+
+describe('dry-run mode', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env['GITHUB_TOKEN'] = 'test-token';
+    process.env['ANTHROPIC_API_KEY'] = 'test-key';
+    process.env['DRY_RUN'] = 'true';
+    // CRYYER_REPO is intentionally not set to verify it's not required in dry-run
+    delete process.env['CRYYER_REPO'];
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('prints draft to stdout and skips issue creation when DRY_RUN=true', async () => {
+    const mockProduct = {
+      id: 'test-app',
+      name: 'Test App',
+      voice: 'friendly',
+      repo: 'owner/test-app',
+      emailSubjectTemplate: 'Weekly update {{weekOf}}',
+    };
+    const mockActivity = { prs: [], releases: [], commits: [] };
+    const mockDraft = { subject: 'Test Subject', body: 'Test body content' };
+
+    (loadProducts as Mock).mockReturnValue([mockProduct]);
+    (gatherWeeklyActivity as Mock).mockResolvedValue(mockActivity);
+    (generateEmailDraft as Mock).mockResolvedValue(mockDraft);
+
+    const mockOctokitInstance = {
+      rest: {
+        issues: {
+          getLabel: vi.fn(),
+          createLabel: vi.fn(),
+          create: vi.fn(),
+        },
+      },
+    };
+    (Octokit as unknown as Mock).mockImplementation(function () {
+      return mockOctokitInstance;
+    });
+    (createLLMProvider as Mock).mockReturnValue({});
+
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await main();
+
+    // Issue creation should NOT have been called
+    expect(mockOctokitInstance.rest.issues.create).not.toHaveBeenCalled();
+    expect(mockOctokitInstance.rest.issues.getLabel).not.toHaveBeenCalled();
+
+    // Output should contain the draft content
+    const output = consoleSpy.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(output).toContain('[DRY RUN]');
+    expect(output).toContain('Test Subject');
+
+    consoleSpy.mockRestore();
+  });
+
+  it('does not require CRYYER_REPO in dry-run mode', async () => {
+    delete process.env['CRYYER_REPO'];
+
+    (loadProducts as Mock).mockReturnValue([]);
+    (Octokit as unknown as Mock).mockImplementation(function () {
+      return { rest: { issues: {} } };
+    });
+    (createLLMProvider as Mock).mockReturnValue({});
+
+    await expect(main()).resolves.toBeUndefined();
   });
 });

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -3,7 +3,6 @@ import type { Mock } from 'vitest';
 
 // Mock all external modules before importing
 vi.mock('../config.js', () => ({
-  loadConfig: vi.fn(),
   loadProducts: vi.fn(),
 }));
 vi.mock('../gather.js', () => ({
@@ -30,8 +29,8 @@ vi.mock('resend', () => ({
   Resend: vi.fn(function ResendMock() {}),
 }));
 
-import { getWeekOf, main } from '../index.js';
-import { loadConfig, loadProducts } from '../config.js';
+import { getWeekOf, isDryRun, main } from '../index.js';
+import { loadProducts } from '../config.js';
 import { gatherWeeklyActivity } from '../gather.js';
 import { generateEmailDraft } from '../summarize.js';
 import { sendWeeklyEmails } from '../send.js';
@@ -76,7 +75,11 @@ describe('main orchestration', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    process.env['GITHUB_TOKEN'] = 'test-token';
+    process.env['RESEND_API_KEY'] = 'resend-key';
+    process.env['FROM_EMAIL'] = 'from@example.com';
     process.env['ANTHROPIC_API_KEY'] = 'test-key';
+    delete process.env['DRY_RUN'];
   });
 
   afterEach(() => {
@@ -84,11 +87,6 @@ describe('main orchestration', () => {
   });
 
   it('sends emails to subscribers for each product', async () => {
-    const mockConfig = {
-      githubToken: 'token',
-      resendApiKey: 'resend-key',
-      fromEmail: 'from@example.com',
-    };
     const mockProduct = {
       id: 'test-app',
       name: 'Test App',
@@ -100,7 +98,6 @@ describe('main orchestration', () => {
     const mockActivity = { prs: [], releases: [], commits: [] };
     const mockDraft = { subject: 'Test Subject', body: 'Test body' };
 
-    (loadConfig as Mock).mockReturnValue(mockConfig);
     (loadProducts as Mock).mockReturnValue([mockProduct]);
     (gatherWeeklyActivity as Mock).mockResolvedValue(mockActivity);
     (generateEmailDraft as Mock).mockResolvedValue(mockDraft);
@@ -132,7 +129,7 @@ describe('main orchestration', () => {
       mockSubscribers,
       { subject: mockDraft.subject, body: mockDraft.body },
       expect.any(String),
-      mockConfig.fromEmail,
+      'from@example.com',
       undefined
     );
     expect(mockStore.recordEmailSent).toHaveBeenCalledWith(
@@ -143,11 +140,6 @@ describe('main orchestration', () => {
   });
 
   it('skips sending if no subscribers', async () => {
-    const mockConfig = {
-      githubToken: 'token',
-      resendApiKey: 'resend-key',
-      fromEmail: 'from@example.com',
-    };
     const mockProduct = {
       id: 'test-app',
       name: 'Test App',
@@ -156,7 +148,6 @@ describe('main orchestration', () => {
       emailSubjectTemplate: '',
     };
 
-    (loadConfig as Mock).mockReturnValue(mockConfig);
     (loadProducts as Mock).mockReturnValue([mockProduct]);
     (gatherWeeklyActivity as Mock).mockResolvedValue({ prs: [], releases: [], commits: [] });
     (generateEmailDraft as Mock).mockResolvedValue({ subject: 'S', body: 'B' });
@@ -175,11 +166,6 @@ describe('main orchestration', () => {
   });
 
   it('handles errors per product without stopping other products', async () => {
-    const mockConfig = {
-      githubToken: 'token',
-      resendApiKey: 'resend-key',
-      fromEmail: 'from@example.com',
-    };
     const product1 = {
       id: 'app1',
       name: 'App 1',
@@ -195,7 +181,6 @@ describe('main orchestration', () => {
       emailSubjectTemplate: '',
     };
 
-    (loadConfig as Mock).mockReturnValue(mockConfig);
     (loadProducts as Mock).mockReturnValue([product1, product2]);
     (gatherWeeklyActivity as Mock)
       .mockRejectedValueOnce(new Error('API error'))
@@ -215,5 +200,99 @@ describe('main orchestration', () => {
 
     // Both products should have been attempted
     expect(gatherWeeklyActivity).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('isDryRun', () => {
+  const originalEnv = { ...process.env };
+  const originalArgv = [...process.argv];
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    process.argv = [...originalArgv];
+  });
+
+  it('returns false by default', () => {
+    delete process.env['DRY_RUN'];
+    process.argv = process.argv.filter((a) => a !== '--dry-run');
+    expect(isDryRun()).toBe(false);
+  });
+
+  it('returns true when DRY_RUN=true', () => {
+    process.env['DRY_RUN'] = 'true';
+    expect(isDryRun()).toBe(true);
+  });
+
+  it('returns true when --dry-run flag is passed', () => {
+    delete process.env['DRY_RUN'];
+    process.argv = [...process.argv, '--dry-run'];
+    expect(isDryRun()).toBe(true);
+  });
+});
+
+describe('dry-run mode', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env['GITHUB_TOKEN'] = 'test-token';
+    process.env['ANTHROPIC_API_KEY'] = 'test-key';
+    process.env['DRY_RUN'] = 'true';
+    // RESEND_API_KEY and FROM_EMAIL intentionally unset to verify they're not required
+    delete process.env['RESEND_API_KEY'];
+    delete process.env['FROM_EMAIL'];
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('prints draft to stdout and skips email sending when DRY_RUN=true', async () => {
+    const mockProduct = {
+      id: 'test-app',
+      name: 'Test App',
+      voice: 'friendly',
+      repo: 'owner/test-app',
+      emailSubjectTemplate: 'Weekly update {{weekOf}}',
+    };
+    const mockSubscribers = [{ email: 'user@example.com' }];
+    const mockDraft = { subject: 'Dry Run Subject', body: 'Dry run body content' };
+
+    (loadProducts as Mock).mockReturnValue([mockProduct]);
+    (gatherWeeklyActivity as Mock).mockResolvedValue({ prs: [], releases: [], commits: [] });
+    (generateEmailDraft as Mock).mockResolvedValue(mockDraft);
+
+    const mockStore = {
+      getSubscribers: vi.fn().mockResolvedValue(mockSubscribers),
+      recordEmailSent: vi.fn(),
+    };
+    (createSubscriberStore as Mock).mockReturnValue(mockStore);
+    (createLLMProvider as Mock).mockReturnValue({});
+
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await main();
+
+    // Emails should NOT have been sent
+    expect(sendWeeklyEmails).not.toHaveBeenCalled();
+    expect(mockStore.recordEmailSent).not.toHaveBeenCalled();
+
+    // Output should contain preview
+    const output = consoleSpy.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(output).toContain('[DRY RUN]');
+    expect(output).toContain('Dry Run Subject');
+
+    consoleSpy.mockRestore();
+  });
+
+  it('does not require RESEND_API_KEY or FROM_EMAIL in dry-run mode', async () => {
+    delete process.env['RESEND_API_KEY'];
+    delete process.env['FROM_EMAIL'];
+
+    (loadProducts as Mock).mockReturnValue([]);
+    (createSubscriberStore as Mock).mockReturnValue({ getSubscribers: vi.fn() });
+    (createLLMProvider as Mock).mockReturnValue({});
+
+    await expect(main()).resolves.toBeUndefined();
   });
 });

--- a/src/__tests__/init.test.ts
+++ b/src/__tests__/init.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import type { Mock } from 'vitest';
+
+vi.mock('readline/promises', () => ({
+  createInterface: vi.fn(),
+}));
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>();
+  return {
+    ...actual,
+    existsSync: vi.fn(),
+    readFileSync: vi.fn(),
+    writeFileSync: vi.fn(),
+    mkdirSync: vi.fn(),
+  };
+});
+
+import { sanitizeId, main } from '../init.js';
+import { createInterface } from 'readline/promises';
+import { existsSync, writeFileSync, mkdirSync } from 'fs';
+
+describe('sanitizeId', () => {
+  it('lowercases the input', () => {
+    expect(sanitizeId('MyApp')).toBe('myapp');
+  });
+
+  it('replaces spaces with hyphens', () => {
+    expect(sanitizeId('My App')).toBe('my-app');
+  });
+
+  it('replaces special characters with hyphens', () => {
+    expect(sanitizeId('My App!')).toBe('my-app');
+  });
+
+  it('collapses multiple hyphens', () => {
+    expect(sanitizeId('My  App')).toBe('my-app');
+  });
+
+  it('strips leading and trailing hyphens', () => {
+    expect(sanitizeId('!MyApp!')).toBe('myapp');
+  });
+
+  it('handles numeric characters', () => {
+    expect(sanitizeId('App 2.0')).toBe('app-2-0');
+  });
+});
+
+describe('main (init)', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function makeRl(answers: string[]) {
+    let callIndex = 0;
+    const rl = {
+      question: vi.fn().mockImplementation(() => Promise.resolve(answers[callIndex++] ?? '')),
+      close: vi.fn(),
+    };
+    (createInterface as Mock).mockReturnValue(rl);
+    return rl;
+  }
+
+  it('writes product YAML with provided values', async () => {
+    (existsSync as Mock).mockReturnValue(false); // products dir exists check, file doesn't exist
+
+    // Answers: name, id (blank=default), repo, subject (blank=default), voice
+    makeRl(['My App', '', 'acme/my-app', '', 'Friendly tone']);
+
+    await main();
+
+    expect(writeFileSync).toHaveBeenCalledWith(
+      expect.stringContaining('my-app.yaml'),
+      expect.stringContaining('acme/my-app'),
+      'utf-8'
+    );
+  });
+
+  it('uses custom product ID when provided', async () => {
+    (existsSync as Mock).mockReturnValue(false);
+    makeRl(['My App', 'custom-id', 'acme/my-app', '', 'Friendly tone']);
+
+    await main();
+
+    expect(writeFileSync).toHaveBeenCalledWith(
+      expect.stringContaining('custom-id.yaml'),
+      expect.any(String),
+      'utf-8'
+    );
+  });
+
+  it('creates products dir if it does not exist', async () => {
+    (existsSync as Mock).mockReturnValue(false);
+    makeRl(['My App', '', 'acme/my-app', '', 'Friendly tone']);
+
+    await main();
+
+    expect(mkdirSync).toHaveBeenCalledWith(expect.stringContaining('products'), { recursive: true });
+  });
+
+  it('aborts if user declines overwrite', async () => {
+    // First existsSync returns false (products dir), second returns true (yaml file already exists)
+    (existsSync as Mock)
+      .mockReturnValueOnce(true) // products dir exists
+      .mockReturnValueOnce(true); // yaml file already exists
+
+    // Answers: name, id, repo, subject, voice, overwrite=N
+    makeRl(['My App', '', 'acme/my-app', '', 'Friendly tone', 'N']);
+
+    await main();
+
+    // Should not write the file
+    expect(writeFileSync).not.toHaveBeenCalled();
+  });
+
+  it('throws when product name is empty', async () => {
+    (existsSync as Mock).mockReturnValue(false);
+    makeRl(['']); // empty name
+
+    await expect(main()).rejects.toThrow('Product name is required');
+  });
+
+  it('throws when repo format is invalid', async () => {
+    (existsSync as Mock).mockReturnValue(false);
+    makeRl(['My App', '', 'invalid-repo-no-slash', '', 'Friendly tone']);
+
+    await expect(main()).rejects.toThrow('owner/repo format');
+  });
+
+  it('throws when voice is empty', async () => {
+    (existsSync as Mock).mockReturnValue(false);
+    makeRl(['My App', '', 'acme/my-app', '', '']); // empty voice
+
+    await expect(main()).rejects.toThrow('Voice/tone is required');
+  });
+});

--- a/src/__tests__/send-on-close.test.ts
+++ b/src/__tests__/send-on-close.test.ts
@@ -1,5 +1,18 @@
-import { describe, it, expect } from 'vitest';
-import { parseIssueBody } from '../send-on-close.js';
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
+import type { Mock } from 'vitest';
+
+// Mock external modules before importing
+vi.mock('../config.js', () => ({ loadProducts: vi.fn() }));
+vi.mock('../subscriber-store.js', () => ({ createSubscriberStore: vi.fn() }));
+vi.mock('../send.js', () => ({ sendWeeklyEmails: vi.fn() }));
+vi.mock('octokit', () => ({ Octokit: vi.fn(function OctokitMock() {}) }));
+vi.mock('resend', () => ({ Resend: vi.fn(function ResendMock() {}) }));
+
+import { parseIssueBody, isDryRun, main } from '../send-on-close.js';
+import { loadProducts } from '../config.js';
+import { createSubscriberStore } from '../subscriber-store.js';
+import { sendWeeklyEmails } from '../send.js';
+import { Octokit } from 'octokit';
 
 describe('parseIssueBody', () => {
   it('parses a well-formed issue body', () => {
@@ -38,5 +51,121 @@ describe('parseIssueBody', () => {
       subject: 'Spaced Subject',
       emailBody: 'Spaced body',
     });
+  });
+});
+
+describe('isDryRun', () => {
+  const originalEnv = { ...process.env };
+  const originalArgv = [...process.argv];
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    process.argv = [...originalArgv];
+  });
+
+  it('returns false by default', () => {
+    delete process.env['DRY_RUN'];
+    process.argv = process.argv.filter((a) => a !== '--dry-run');
+    expect(isDryRun()).toBe(false);
+  });
+
+  it('returns true when DRY_RUN=true', () => {
+    process.env['DRY_RUN'] = 'true';
+    expect(isDryRun()).toBe(true);
+  });
+});
+
+describe('main dry-run mode', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env['GITHUB_TOKEN'] = 'test-token';
+    process.env['ISSUE_NUMBER'] = '42';
+    process.env['GITHUB_REPOSITORY'] = 'owner/repo';
+    process.env['DRY_RUN'] = 'true';
+    // RESEND_API_KEY and FROM_EMAIL intentionally absent in dry-run
+    delete process.env['RESEND_API_KEY'];
+    delete process.env['FROM_EMAIL'];
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('prints preview and skips sending when DRY_RUN=true', async () => {
+    const mockProduct = {
+      id: 'test-app',
+      name: 'Test App',
+      voice: 'friendly',
+      repo: 'owner/test-app',
+      emailSubjectTemplate: 'Weekly update',
+    };
+    const issueBody = '**Subject:** Test Subject\n\n---\n\nTest email body content';
+
+    const mockOctokitInstance = {
+      rest: {
+        issues: {
+          get: vi.fn().mockResolvedValue({
+            data: {
+              body: issueBody,
+              labels: [{ name: 'draft' }, { name: 'test-app' }],
+            },
+          }),
+          createComment: vi.fn(),
+          addLabels: vi.fn(),
+          update: vi.fn(),
+        },
+      },
+    };
+    (Octokit as unknown as Mock).mockImplementation(function () {
+      return mockOctokitInstance;
+    });
+    (loadProducts as Mock).mockReturnValue([mockProduct]);
+
+    const mockStore = { getSubscribers: vi.fn().mockResolvedValue([{ email: 'user@example.com' }]) };
+    (createSubscriberStore as Mock).mockReturnValue(mockStore);
+
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await main();
+
+    expect(sendWeeklyEmails).not.toHaveBeenCalled();
+
+    const output = consoleSpy.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(output).toContain('[DRY RUN]');
+    expect(output).toContain('Test Subject');
+
+    consoleSpy.mockRestore();
+  });
+
+  it('does not require RESEND_API_KEY in dry-run mode', async () => {
+    delete process.env['RESEND_API_KEY'];
+    delete process.env['FROM_EMAIL'];
+
+    const mockOctokitInstance = {
+      rest: {
+        issues: {
+          get: vi.fn().mockResolvedValue({
+            data: {
+              body: '**Subject:** S\n\n---\n\nB',
+              labels: [{ name: 'draft' }, { name: 'my-product' }],
+            },
+          }),
+        },
+      },
+    };
+    (Octokit as unknown as Mock).mockImplementation(function () {
+      return mockOctokitInstance;
+    });
+    (loadProducts as Mock).mockReturnValue([
+      { id: 'my-product', name: 'My Product', voice: '', repo: 'o/r', emailSubjectTemplate: '' },
+    ]);
+    (createSubscriberStore as Mock).mockReturnValue({
+      getSubscribers: vi.fn().mockResolvedValue([{ email: 'u@e.com' }]),
+    });
+
+    await expect(main()).resolves.toBeUndefined();
+    expect(sendWeeklyEmails).not.toHaveBeenCalled();
   });
 });

--- a/src/check.ts
+++ b/src/check.ts
@@ -1,0 +1,220 @@
+import { join } from 'path';
+import { fileURLToPath } from 'url';
+import { existsSync } from 'fs';
+import { Octokit } from 'octokit';
+import { loadProducts } from './config.js';
+
+export interface CheckResult {
+  name: string;
+  passed: boolean;
+  message: string;
+}
+
+export async function checkProducts(productsDir: string): Promise<CheckResult> {
+  if (!existsSync(productsDir)) {
+    return { name: 'Product configs', passed: false, message: `products/ directory not found: ${productsDir}` };
+  }
+
+  let products;
+  try {
+    products = loadProducts(productsDir);
+  } catch (err) {
+    return { name: 'Product configs', passed: false, message: `Failed to load products: ${String(err)}` };
+  }
+
+  if (products.length === 0) {
+    return { name: 'Product configs', passed: false, message: 'No product YAML files found in products/' };
+  }
+
+  const errors: string[] = [];
+  for (const product of products) {
+    if (!product.id) errors.push(`A product is missing the 'id' field`);
+    if (!product.name) errors.push(`Product '${product.id}' is missing the 'name' field`);
+    if (!product.voice) errors.push(`Product '${product.id}' is missing the 'voice' field`);
+    if (!product.repo && !product.githubRepo) errors.push(`Product '${product.id}' is missing the 'repo' field`);
+    if (!product.emailSubjectTemplate)
+      errors.push(`Product '${product.id}' is missing the 'emailSubjectTemplate' field`);
+  }
+
+  if (errors.length > 0) {
+    return { name: 'Product configs', passed: false, message: errors.join('; ') };
+  }
+
+  return {
+    name: 'Product configs',
+    passed: true,
+    message: `${products.length} product(s) validated successfully`,
+  };
+}
+
+export async function checkGitHub(): Promise<CheckResult> {
+  const token = process.env['GITHUB_TOKEN'];
+  if (!token) {
+    return { name: 'GitHub token', passed: false, message: 'GITHUB_TOKEN is not set' };
+  }
+
+  try {
+    const octokit = new Octokit({ auth: token });
+    const { data } = await octokit.rest.users.getAuthenticated();
+    return { name: 'GitHub token', passed: true, message: `Authenticated as ${data.login}` };
+  } catch (err) {
+    return { name: 'GitHub token', passed: false, message: `Authentication failed: ${String(err)}` };
+  }
+}
+
+export function checkLLMProvider(): CheckResult {
+  const provider = process.env['LLM_PROVIDER'] || 'anthropic';
+  const keyMap: Record<string, string> = {
+    anthropic: 'ANTHROPIC_API_KEY',
+    openai: 'OPENAI_API_KEY',
+    gemini: 'GEMINI_API_KEY',
+  };
+
+  const envKey = keyMap[provider];
+  if (!envKey) {
+    return {
+      name: 'LLM provider',
+      passed: false,
+      message: `Unknown LLM_PROVIDER: '${provider}'. Supported: anthropic, openai, gemini`,
+    };
+  }
+
+  const apiKey = process.env[envKey];
+  if (!apiKey) {
+    return {
+      name: 'LLM provider',
+      passed: false,
+      message: `LLM_PROVIDER is '${provider}' but ${envKey} is not set`,
+    };
+  }
+
+  return {
+    name: 'LLM provider',
+    passed: true,
+    message: `Provider '${provider}' configured (${envKey} is set)`,
+  };
+}
+
+export async function checkSubscriberStore(): Promise<CheckResult> {
+  const store = process.env['SUBSCRIBER_STORE'] || 'supabase';
+
+  if (store === 'supabase') {
+    const url = process.env['SUPABASE_URL'];
+    const key = process.env['SUPABASE_SERVICE_KEY'];
+    const missing = [!url && 'SUPABASE_URL', !key && 'SUPABASE_SERVICE_KEY'].filter(Boolean).join(', ');
+    if (missing) {
+      return {
+        name: 'Subscriber store',
+        passed: false,
+        message: `SUBSCRIBER_STORE is 'supabase' but missing: ${missing}`,
+      };
+    }
+    try {
+      const { createClient } = await import('@supabase/supabase-js');
+      const db = createClient(url!, key!);
+      const { error } = await db.from('beta_testers').select('count').limit(0);
+      if (error) throw error;
+      return { name: 'Subscriber store', passed: true, message: 'Supabase connection verified' };
+    } catch (err) {
+      return {
+        name: 'Subscriber store',
+        passed: false,
+        message: `Supabase connection failed: ${String(err)}`,
+      };
+    }
+  }
+
+  if (store === 'json') {
+    const subscribersPath = process.env['SUBSCRIBERS_JSON_PATH'] || './subscribers.json';
+    if (!existsSync(subscribersPath)) {
+      return {
+        name: 'Subscriber store',
+        passed: false,
+        message: `SUBSCRIBER_STORE is 'json' but file not found: ${subscribersPath}`,
+      };
+    }
+    return { name: 'Subscriber store', passed: true, message: `JSON file found: ${subscribersPath}` };
+  }
+
+  if (store === 'google-sheets') {
+    const spreadsheetId = process.env['GOOGLE_SHEETS_SPREADSHEET_ID'];
+    const email = process.env['GOOGLE_SERVICE_ACCOUNT_EMAIL'];
+    const privateKey = process.env['GOOGLE_PRIVATE_KEY'];
+    const missing = [
+      !spreadsheetId && 'GOOGLE_SHEETS_SPREADSHEET_ID',
+      !email && 'GOOGLE_SERVICE_ACCOUNT_EMAIL',
+      !privateKey && 'GOOGLE_PRIVATE_KEY',
+    ]
+      .filter(Boolean)
+      .join(', ');
+    if (missing) {
+      return {
+        name: 'Subscriber store',
+        passed: false,
+        message: `SUBSCRIBER_STORE is 'google-sheets' but missing: ${missing}`,
+      };
+    }
+    return {
+      name: 'Subscriber store',
+      passed: true,
+      message: `Google Sheets credentials are set`,
+    };
+  }
+
+  return {
+    name: 'Subscriber store',
+    passed: false,
+    message: `Unknown SUBSCRIBER_STORE: '${store}'. Supported: supabase, json, google-sheets`,
+  };
+}
+
+export function checkEmailConfig(): CheckResult {
+  const resendKey = process.env['RESEND_API_KEY'];
+  const fromEmail = process.env['FROM_EMAIL'];
+  const missing = [!resendKey && 'RESEND_API_KEY', !fromEmail && 'FROM_EMAIL'].filter(Boolean).join(', ');
+  if (missing) {
+    return { name: 'Email (Resend)', passed: false, message: `Missing required variables: ${missing}` };
+  }
+  return { name: 'Email (Resend)', passed: true, message: 'RESEND_API_KEY and FROM_EMAIL are set' };
+}
+
+export async function runChecks(productsDir?: string): Promise<CheckResult[]> {
+  const dir = productsDir ?? join(process.cwd(), 'products');
+  const [products, github, subscriber] = await Promise.all([
+    checkProducts(dir),
+    checkGitHub(),
+    checkSubscriberStore(),
+  ]);
+  const llm = checkLLMProvider();
+  const email = checkEmailConfig();
+  return [products, github, llm, subscriber, email];
+}
+
+async function main(): Promise<void> {
+  console.log('\nCryyer Health Check');
+  console.log('='.repeat(40));
+
+  const results = await runChecks();
+
+  let allPassed = true;
+  for (const result of results) {
+    const icon = result.passed ? '✅' : '❌';
+    console.log(`${icon} ${result.name}: ${result.message}`);
+    if (!result.passed) allPassed = false;
+  }
+
+  console.log('='.repeat(40));
+  if (allPassed) {
+    console.log('All checks passed.');
+  } else {
+    console.log('Some checks failed. Fix the issues above and re-run.');
+    process.exitCode = 1;
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((err) => {
+    console.error('Fatal error:', err);
+    process.exit(1);
+  });
+}

--- a/src/draft.ts
+++ b/src/draft.ts
@@ -6,9 +6,21 @@ import { gatherWeeklyActivity } from './gather.js';
 import { generateEmailDraft } from './summarize.js';
 import { createLLMProvider } from './llm-provider.js';
 
+export function isDryRun(): boolean {
+  return process.env['DRY_RUN'] === 'true' || process.argv.includes('--dry-run');
+}
+
 async function main(): Promise<void> {
   const githubToken = requireEnv('GITHUB_TOKEN');
-  const cryyerRepo = requireEnv('CRYYER_REPO'); // e.g. "owner/cryyer"
+  const dryRun = isDryRun();
+
+  // Only require CRYYER_REPO when actually creating issues
+  let cryyerOwner = '';
+  let cryyerRepoName = '';
+  if (!dryRun) {
+    const cryyerRepo = requireEnv('CRYYER_REPO'); // e.g. "owner/cryyer"
+    [cryyerOwner, cryyerRepoName] = cryyerRepo.split('/');
+  }
 
   const productsDir = join(process.cwd(), 'products');
   const products = loadProducts(productsDir);
@@ -16,12 +28,14 @@ async function main(): Promise<void> {
   const octokit = new Octokit({ auth: githubToken });
   const llm = createLLMProvider();
 
-  const [cryyerOwner, cryyerRepoName] = cryyerRepo.split('/');
-
   const weekOf = getWeekOf();
   const since = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
 
-  console.log(`Generating draft issues for week of ${weekOf}`);
+  if (dryRun) {
+    console.log(`[DRY RUN] Generating draft previews for week of ${weekOf}`);
+  } else {
+    console.log(`Generating draft issues for week of ${weekOf}`);
+  }
 
   for (const product of products) {
     console.log(`Processing product: ${product.name}`);
@@ -33,18 +47,25 @@ async function main(): Promise<void> {
       const issueTitle = `[${product.name}] Weekly Update — ${weekOf}`;
       const issueBody = `**Subject:** ${draft.subject}\n\n---\n\n${draft.body}`;
 
-      await ensureLabel(octokit, cryyerOwner, cryyerRepoName, 'draft', '0075ca');
-      await ensureLabel(octokit, cryyerOwner, cryyerRepoName, product.id, 'e4e669');
+      if (dryRun) {
+        console.log(`\n[DRY RUN] ${product.name} — draft preview:`);
+        console.log(`Title: ${issueTitle}`);
+        console.log(`\n${issueBody}`);
+        console.log('---');
+      } else {
+        await ensureLabel(octokit, cryyerOwner, cryyerRepoName, 'draft', '0075ca');
+        await ensureLabel(octokit, cryyerOwner, cryyerRepoName, product.id, 'e4e669');
 
-      const { data: issue } = await octokit.rest.issues.create({
-        owner: cryyerOwner,
-        repo: cryyerRepoName,
-        title: issueTitle,
-        body: issueBody,
-        labels: ['draft', product.id],
-      });
+        const { data: issue } = await octokit.rest.issues.create({
+          owner: cryyerOwner,
+          repo: cryyerRepoName,
+          title: issueTitle,
+          body: issueBody,
+          labels: ['draft', product.id],
+        });
 
-      console.log(`  Created issue: ${issue.html_url}`);
+        console.log(`  Created issue: ${issue.html_url}`);
+      }
     } catch (err) {
       console.error(`  Error processing ${product.name}:`, err);
       process.exitCode = 1;

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,27 +2,47 @@ import { join } from 'path';
 import { fileURLToPath } from 'url';
 import { Octokit } from 'octokit';
 import { Resend } from 'resend';
-import { loadConfig, loadProducts } from './config.js';
+import { loadProducts } from './config.js';
 import { gatherWeeklyActivity } from './gather.js';
 import { generateEmailDraft } from './summarize.js';
 import { sendWeeklyEmails } from './send.js';
 import { createLLMProvider } from './llm-provider.js';
 import { createSubscriberStore } from './subscriber-store.js';
 
+export function isDryRun(): boolean {
+  return process.env['DRY_RUN'] === 'true' || process.argv.includes('--dry-run');
+}
+
+function requireEnv(key: string): string {
+  const value = process.env[key];
+  if (!value) throw new Error(`Missing required environment variable: ${key}`);
+  return value;
+}
+
 async function main(): Promise<void> {
-  const config = loadConfig();
+  const dryRun = isDryRun();
+
+  const githubToken = requireEnv('GITHUB_TOKEN');
+  // Resend credentials are only needed when actually sending emails
+  const resendApiKey = dryRun ? (process.env['RESEND_API_KEY'] ?? '') : requireEnv('RESEND_API_KEY');
+  const fromEmail = dryRun ? (process.env['FROM_EMAIL'] ?? '') : requireEnv('FROM_EMAIL');
+
   const productsDir = join(process.cwd(), 'products');
   const products = loadProducts(productsDir);
 
-  const octokit = new Octokit({ auth: config.githubToken });
+  const octokit = new Octokit({ auth: githubToken });
   const llm = createLLMProvider();
-  const resend = new Resend(config.resendApiKey);
+  const resend = dryRun ? null : new Resend(resendApiKey);
   const store = createSubscriberStore();
 
   const weekOf = getWeekOf();
   const since = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
 
-  console.log(`Running cryyer for week of ${weekOf}`);
+  if (dryRun) {
+    console.log(`[DRY RUN] Running cryyer preview for week of ${weekOf}`);
+  } else {
+    console.log(`Running cryyer for week of ${weekOf}`);
+  }
 
   for (const product of products) {
     console.log(`Processing product: ${product.name}`);
@@ -32,22 +52,31 @@ async function main(): Promise<void> {
       const draft = await generateEmailDraft(llm, product, activity, weekOf);
       const subscribers = await store.getSubscribers(product.id);
 
+      if (dryRun) {
+        console.log(`\n[DRY RUN] ${product.name}:`);
+        console.log(`  Subscribers: ${subscribers.length}`);
+        console.log(`  Subject: ${draft.subject}`);
+        console.log(`\n${draft.body}`);
+        console.log('---');
+        continue;
+      }
+
       if (subscribers.length === 0) {
         console.log(`  No subscribers for ${product.name}, skipping`);
         continue;
       }
 
-      const fromName = product.from_name ?? process.env['FROM_NAME'] ?? 'Cryyer Updates';
-      const fromEmail = product.from_email ?? config.fromEmail;
+      const productFromName = product.from_name ?? process.env['FROM_NAME'] ?? 'Cryyer Updates';
+      const productFromEmail = product.from_email ?? fromEmail;
       const replyTo = product.reply_to;
 
       const stats = await sendWeeklyEmails(
-        resend,
+        resend!,
         product,
         subscribers,
         { subject: draft.subject, body: draft.body },
-        fromName,
-        fromEmail,
+        productFromName,
+        productFromEmail,
         replyTo
       );
 

--- a/src/init.ts
+++ b/src/init.ts
@@ -1,0 +1,94 @@
+import { join } from 'path';
+import { fileURLToPath } from 'url';
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
+import { createInterface } from 'readline/promises';
+import { stdin as input, stdout as output } from 'process';
+import { stringify as stringifyYaml } from 'yaml';
+
+export function sanitizeId(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9-]/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+export async function main(): Promise<void> {
+  const rl = createInterface({ input, output });
+
+  console.log('Cryyer Product Setup');
+  console.log('='.repeat(40));
+  console.log('This will create a new product configuration file.\n');
+
+  try {
+    const rawName = await rl.question('Product name (e.g., "My App"): ');
+    const name = rawName.trim();
+    if (!name) throw new Error('Product name is required');
+
+    const defaultId = sanitizeId(name);
+    const rawId = await rl.question(`Product ID [${defaultId}]: `);
+    const id = rawId.trim() || defaultId;
+    if (!id) throw new Error('Product ID is required');
+
+    const rawRepo = await rl.question('GitHub repo (owner/repo, e.g., "acme/my-app"): ');
+    const repo = rawRepo.trim();
+    if (!repo || !repo.includes('/')) throw new Error('GitHub repo must be in owner/repo format');
+
+    const defaultSubjectTemplate = `{{weekOf}} Weekly Update — ${name}`;
+    const rawSubjectTemplate = await rl.question(`Email subject template [${defaultSubjectTemplate}]: `);
+    const emailSubjectTemplate = rawSubjectTemplate.trim() || defaultSubjectTemplate;
+
+    console.log('\nVoice/tone: Describe how this product should communicate with beta testers.');
+    console.log('Example: "Friendly and technical, focused on developer experience"');
+    const rawVoice = await rl.question('Voice/tone: ');
+    const voice = rawVoice.trim();
+    if (!voice) throw new Error('Voice/tone is required');
+
+    const productsDir = join(process.cwd(), 'products');
+    if (!existsSync(productsDir)) {
+      mkdirSync(productsDir, { recursive: true });
+    }
+
+    const outputPath = join(productsDir, `${id}.yaml`);
+
+    if (existsSync(outputPath)) {
+      const rawOverwrite = await rl.question(`File already exists: ${outputPath}\nOverwrite? (y/N): `);
+      if (rawOverwrite.trim().toLowerCase() !== 'y') {
+        console.log('Aborted.');
+        return;
+      }
+    }
+
+    const productConfig = { id, name, repo, emailSubjectTemplate, voice };
+    const yaml = `# Product configuration for ${name}\n` + stringifyYaml(productConfig);
+    writeFileSync(outputPath, yaml, 'utf-8');
+    console.log(`\nProduct config written to: ${outputPath}`);
+
+    // Optionally scaffold .env from .env.example
+    const envExamplePath = join(process.cwd(), '.env.example');
+    const envPath = join(process.cwd(), '.env');
+    if (existsSync(envExamplePath) && !existsSync(envPath)) {
+      const rawScaffold = await rl.question('\nScaffold .env from .env.example? (Y/n): ');
+      if (rawScaffold.trim().toLowerCase() !== 'n') {
+        const envContent = readFileSync(envExamplePath, 'utf-8');
+        writeFileSync(envPath, envContent, 'utf-8');
+        console.log('.env created from .env.example. Fill in your actual values.');
+      }
+    }
+
+    console.log('\nDone! Next steps:');
+    console.log(`  1. Review: ${outputPath}`);
+    console.log('  2. Set required environment variables (see .env.example)');
+    console.log('  3. Run: pnpm run check  (validate your setup)');
+    console.log('  4. Run: DRY_RUN=true pnpm run dev  (preview emails)');
+  } finally {
+    rl.close();
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((err) => {
+    console.error('Fatal error:', err);
+    process.exit(1);
+  });
+}

--- a/src/send-on-close.ts
+++ b/src/send-on-close.ts
@@ -12,6 +12,10 @@ function requireEnv(key: string): string {
   return value;
 }
 
+export function isDryRun(): boolean {
+  return process.env['DRY_RUN'] === 'true' || process.argv.includes('--dry-run');
+}
+
 export function parseIssueBody(body: string): { subject: string; emailBody: string } | null {
   // Body format: **Subject:** ${subject}\n\n---\n\n${body}
   const subjectMatch = body.match(/^\*\*Subject:\*\*\s*(.+)$/m);
@@ -46,15 +50,17 @@ async function ensureLabel(
 }
 
 async function main(): Promise<void> {
+  const dryRun = isDryRun();
   const githubToken = requireEnv('GITHUB_TOKEN');
-  const resendApiKey = requireEnv('RESEND_API_KEY');
-  const fromEmail = requireEnv('FROM_EMAIL');
+  // Resend credentials only needed when actually sending
+  const resendApiKey = dryRun ? (process.env['RESEND_API_KEY'] ?? '') : requireEnv('RESEND_API_KEY');
+  const fromEmail = dryRun ? (process.env['FROM_EMAIL'] ?? '') : requireEnv('FROM_EMAIL');
   const fromName = process.env['FROM_NAME'] ?? 'Cryyer Updates';
   const issueNumber = parseInt(requireEnv('ISSUE_NUMBER'), 10);
   const [repoOwner, repoName] = requireEnv('GITHUB_REPOSITORY').split('/');
 
   const octokit = new Octokit({ auth: githubToken });
-  const resend = new Resend(resendApiKey);
+  const resend = dryRun ? null : new Resend(resendApiKey);
   const store = createSubscriberStore();
 
   // Fetch issue
@@ -124,10 +130,20 @@ async function main(): Promise<void> {
     return;
   }
 
+  // In dry-run mode, print what would be sent instead of sending
+  if (dryRun) {
+    console.log(`\n[DRY RUN] ${product.name} — would send email:`);
+    console.log(`  Subscribers: ${subscribers.length}`);
+    console.log(`  Subject: ${emailContent.subject}`);
+    console.log(`\n${emailContent.body}`);
+    console.log('---');
+    return;
+  }
+
   // Send emails
   let stats;
   try {
-    stats = await sendWeeklyEmails(resend, product, subscribers, emailContent, fromName, fromEmail);
+    stats = await sendWeeklyEmails(resend!, product, subscribers, emailContent, fromName, fromEmail);
   } catch (err) {
     // Re-open issue and add error comment on unexpected send failure
     await octokit.rest.issues.update({
@@ -179,6 +195,8 @@ async function main(): Promise<void> {
     process.exitCode = 1;
   }
 }
+
+export { main };
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
   main().catch((err) => {


### PR DESCRIPTION
Closes #56
Closes #57
Closes #58
Closes #59

## Summary
## Problem

No way to preview what an email would look like without actually sending it or creating a GitHub issue. This makes onboarding a new product risky — you have to go live to see the output.

## Acceptance Criteria

- [ ] Add a `--dry-run` flag or `DRY_RUN=true` env var
- [ ] In dry-run mode: gather activity, generate draft, print to stdout (or save to file) instead of creating an issue or sending email
- [ ] Works with all entry points (`draft.ts`, `send-on-close.ts`, `index.ts`)

## Problem

No way to verify that env vars, API keys, and product YAML configs are all valid before running the pipeline. Users discover misconfiguration only at runtime.

## Acceptance Criteria

- [ ] Add a `cryyer check` or `npm run check` command
- [ ] Validates: required env vars are set, API keys authenticate, product YAML files parse correctly, subscriber store is reachable
- [ ] Clear pass/fail output per check with actionable error messages

## Problem

Adding a new product requires manually creating a YAML file in `products/` and knowing the schema. A guided setup would lower the onboarding bar.

## Acceptance Criteria

- [ ] `cryyer init` or interactive setup that walks through creating a product YAML
- [ ] Prompts for: id, name, repo, voice/tone, email subject template
- [ ] Writes valid YAML to `products/<id>.yaml`
- [ ] Optionally scaffolds `.env` from `.env.example`

## Problem

No issue or PR templates exist. These are standard for OSS projects to guide contributors.

## Acceptance Criteria

- [ ] `.github/ISSUE_TEMPLATE/bug_report.md` with structured bug report form
- [ ] `.github/ISSUE_TEMPLATE/feature_request.md` with feature request form
- [ ] `.github/pull_request_template.md` with checklist (description, testing, breaking changes)

## Changes
75c3a65 feat(#56,#57,#58,#59): add dry-run mode, health check, init command, and GitHub templates

`.env.example
.github/ISSUE_TEMPLATE/bug_report.md
.github/ISSUE_TEMPLATE/feature_request.md
.github/pull_request_template.md
package.json
src/__tests__/check.test.ts
src/__tests__/draft.test.ts
src/__tests__/index.test.ts
src/__tests__/init.test.ts
src/__tests__/send-on-close.test.ts
src/check.ts
src/draft.ts
src/index.ts
src/init.ts
src/send-on-close.ts`

## Acceptance Criteria
- [ ] Add a `--dry-run` flag or `DRY_RUN=true` env var
- [ ] In dry-run mode: gather activity, generate draft, print to stdout (or save to file) instead of creating an issue or sending email
- [ ] Works with all entry points (`draft.ts`, `send-on-close.ts`, `index.ts`)
- [ ] Add a `cryyer check` or `npm run check` command
- [ ] Validates: required env vars are set, API keys authenticate, product YAML files parse correctly, subscriber store is reachable
- [ ] Clear pass/fail output per check with actionable error messages
- [ ] `cryyer init` or interactive setup that walks through creating a product YAML
- [ ] Prompts for: id, name, repo, voice/tone, email subject template
- [ ] Writes valid YAML to `products/<id>.yaml`
- [ ] Optionally scaffolds `.env` from `.env.example`
- [ ] `.github/ISSUE_TEMPLATE/bug_report.md` with structured bug report form
- [ ] `.github/ISSUE_TEMPLATE/feature_request.md` with feature request form
- [ ] `.github/pull_request_template.md` with checklist (description, testing, breaking changes)

## Verification
- Tests: passed
- Branch: `feat/add-dry-run-preview-mode-56`

Automated PR by Ralph | Model: claude-sonnet-4-6 | Duration: 13m