### PR TITLE
feat: wire multi-audience into release pipeline

### DIFF
--- a/.github/workflows/draft-email.yml
+++ b/.github/workflows/draft-email.yml
@@ -32,21 +32,34 @@ jobs:
           fi
           echo "since=$SINCE" >> "$GITHUB_OUTPUT"
 
-      - name: Generate draft
-        uses: atriumn/cryyer/.github/actions/draft-file@v0
-        id: draft
-        with:
-          product: cryyer
-          version: ${{ steps.version.outputs.value }}
-          since: ${{ steps.version.outputs.since }}
-          llm-api-key: ${{ secrets.GEMINI_API_KEY }}
-          llm-provider: gemini
-          llm-model: gemini-3-flash-preview
+      - name: Parse audience IDs
+        id: audiences
+        run: |
+          AUDIENCES=$(grep -A1 '^\s*- id:' products/cryyer.yaml | grep 'id:' | awk '{print $3}' | tr '\n' ' ')
+          echo "list=$AUDIENCES" >> "$GITHUB_OUTPUT"
 
-      - name: Commit draft
+      - name: Generate drafts per audience
+        run: |
+          for AUDIENCE in ${{ steps.audiences.outputs.list }}; do
+            echo "::group::Drafting for audience: $AUDIENCE"
+            npx cryyer@latest draft-file \
+              --product cryyer \
+              --version "${{ steps.version.outputs.value }}" \
+              --since "${{ steps.version.outputs.since }}" \
+              --audience "$AUDIENCE" \
+              --output "drafts/v${{ steps.version.outputs.value }}-${AUDIENCE}.md"
+            echo "::endgroup::"
+          done
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LLM_PROVIDER: gemini
+          LLM_MODEL: gemini-3-flash-preview
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+
+      - name: Commit drafts
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add ${{ steps.draft.outputs.draft-path }}
-          git diff --cached --quiet || git commit -m "chore: draft email for v${{ steps.version.outputs.value }}"
+          git add drafts/
+          git diff --cached --quiet || git commit -m "chore: draft emails for v${{ steps.version.outputs.value }}"
           git push

--- a/.github/workflows/send-email.yml
+++ b/.github/workflows/send-email.yml
@@ -18,12 +18,24 @@ jobs:
           VERSION="${VERSION#v}"
           echo "value=$VERSION" >> "$GITHUB_OUTPUT"
 
-      - name: Send emails
-        uses: atriumn/cryyer/.github/actions/send-file@v0
-        with:
-          product: cryyer
-          draft-path: drafts/v${{ steps.version.outputs.value }}.md
-          from-email: ${{ secrets.FROM_EMAIL }}
-          email-provider: resend
-          email-api-key: ${{ secrets.RESEND_API_KEY }}
-          subscriber-store: json
+      - name: Parse audience IDs
+        id: audiences
+        run: |
+          AUDIENCES=$(grep -A1 '^\s*- id:' products/cryyer.yaml | grep 'id:' | awk '{print $3}' | tr '\n' ' ')
+          echo "list=$AUDIENCES" >> "$GITHUB_OUTPUT"
+
+      - name: Send emails per audience
+        run: |
+          for AUDIENCE in ${{ steps.audiences.outputs.list }}; do
+            echo "::group::Sending for audience: $AUDIENCE"
+            npx cryyer@latest send-file \
+              "drafts/v${{ steps.version.outputs.value }}-${AUDIENCE}.md" \
+              --product cryyer \
+              --audience "$AUDIENCE"
+            echo "::endgroup::"
+          done
+        env:
+          EMAIL_PROVIDER: resend
+          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+          FROM_EMAIL: ${{ secrets.FROM_EMAIL }}
+          SUBSCRIBER_STORE: json

--- a/products/cryyer.yaml
+++ b/products/cryyer.yaml
@@ -1,12 +1,17 @@
 # Product configuration for Cryyer itself (dogfooding)
 id: cryyer
 name: Cryyer
-voice: |
-  Approachable and upbeat, like a teammate sharing good news over coffee.
-  Professional but not stiff — sprinkle in personality without forcing it.
-  Assume readers are developers who know what a PR is, but skip deep implementation details.
-  Focus on what changed and why they should care, not how the sausage is made.
-  Keep it scannable: short paragraphs, clear structure.
-  This is a release update, not a weekly newsletter. Write about what shipped.
 repo: "atriumn/cryyer"
-emailSubjectTemplate: "Cryyer {{version}} — What's New"
+audiences:
+  - id: technical
+    voice: |
+      Developer-focused. Reference PRs, APIs, and breaking changes directly.
+      Assume readers are building on top of Cryyer or contributing to it.
+      This is a release update, not a weekly newsletter. Write about what shipped.
+    emailSubjectTemplate: "Cryyer v{{version}} — Developer Notes"
+  - id: general
+    voice: |
+      Approachable and non-technical. Focus on what's improved and why it matters.
+      Skip implementation details. Keep it short and friendly.
+      This is a release update, not a weekly newsletter. Write about what shipped.
+    emailSubjectTemplate: "Cryyer v{{version}} — What's New"

--- a/subscribers.json
+++ b/subscribers.json
@@ -3,7 +3,8 @@
     "email": "jrojers@gmail.com",
     "name": "Jeff",
     "productIds": [
-      "cryyer"
+      "cryyer:technical",
+      "cryyer:general"
     ]
   }
 ]

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    exclude: ['node_modules', 'dist'],
+    exclude: ['**/node_modules/**', 'dist'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'lcov'],


### PR DESCRIPTION
## Summary
- Replace single voice in `products/cryyer.yaml` with two audiences: `technical` (developer-focused) and `general` (user-friendly)
- Update `draft-email.yml` and `send-email.yml` workflows to loop over audiences, generating/sending per-audience draft files (`drafts/v{version}-{audience}.md`)
- Update `subscribers.json` keys to compound format (`cryyer:technical`, `cryyer:general`)
- Fix vitest config to exclude nested `node_modules` (was picking up `site/node_modules` test files)

## Test plan
- [x] `pnpm test` — 376 tests passing
- [x] `pnpm run typecheck` — clean
- [ ] Push → release-please PR → verify `draft-email.yml` generates two draft files
- [ ] Review both drafts: technical should reference PRs/APIs, general should be friendly

🤖 Generated with [Claude Code](https://claude.com/claude-code)