### PR TITLE
fix: handle deep headings and * list items in email rendering

### DIFF
--- a/products/cryyer.yaml
+++ b/products/cryyer.yaml
@@ -8,10 +8,12 @@ audiences:
       Developer-focused. Reference PRs, APIs, and breaking changes directly.
       Assume readers are building on top of Cryyer or contributing to it.
       This is a release update, not a weekly newsletter. Write about what shipped.
+      Use ## or ### for headings, never #### or deeper. Use - for list items, not *.
     emailSubjectTemplate: "Cryyer v{{version}} — Developer Notes"
   - id: general
     voice: |
       Approachable and non-technical. Focus on what's improved and why it matters.
       Skip implementation details. Keep it short and friendly.
       This is a release update, not a weekly newsletter. Write about what shipped.
+      Use ## or ### for headings, never #### or deeper. Use - for list items, not *.
     emailSubjectTemplate: "Cryyer v{{version}} — What's New"

--- a/src/send.ts
+++ b/src/send.ts
@@ -16,7 +16,8 @@ export type DeliveryStats = BatchResult;
 
 export function markdownToHtml(markdown: string): string {
   let html = markdown
-    // Headers
+    // Headers (h4+ mapped to h3 to avoid tiny text in email clients)
+    .replace(/^#{4,} (.+)$/gm, '<h3>$1</h3>')
     .replace(/^### (.+)$/gm, '<h3>$1</h3>')
     .replace(/^## (.+)$/gm, '<h2>$1</h2>')
     .replace(/^# (.+)$/gm, '<h1>$1</h1>')
@@ -26,8 +27,8 @@ export function markdownToHtml(markdown: string): string {
     .replace(/\*(.+?)\*/g, '<em>$1</em>')
     // Links
     .replace(/\[(.+?)\]\((.+?)\)/g, '<a href="$2">$1</a>')
-    // Unordered list items
-    .replace(/^- (.+)$/gm, '<li>$1</li>');
+    // Unordered list items (- or *)
+    .replace(/^[-*] (.+)$/gm, '<li>$1</li>');
 
   // Wrap consecutive list items in <ul>
   html = html.replace(/((?:<li>.*<\/li>\n?)+)/g, '<ul>\n$1</ul>\n');


### PR DESCRIPTION
## Summary
- `markdownToHtml` now converts `####`+ headings to `<h3>` instead of passing through as raw text
- `*` list items are now handled alongside `-`
- Voice instructions in `products/cryyer.yaml` updated to tell LLM to use `##`/`###` only

## Test plan
- [x] `pnpm test` — 376 tests passing
- [ ] Next release email should render headings and lists correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)