### PR TITLE
chore: rename npm package to @atriumn/cryyer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,7 +16,7 @@ GITHUB_TOKEN=ghp_your_token_here
 RESEND_API_KEY=re_your_key_here
 
 # Gmail OAuth refresh token (required when EMAIL_PROVIDER=gmail)
-# Obtain via: npx cryyer auth gmail
+# Obtain via: npx @atriumn/cryyer auth gmail
 # GMAIL_REFRESH_TOKEN=1//your_refresh_token_here
 
 # Default sender email address

--- a/.github/actions/draft-file/action.yml
+++ b/.github/actions/draft-file/action.yml
@@ -91,7 +91,7 @@ runs:
         if [ -n "${{ inputs.version }}" ]; then
           VERSION_FLAG="--version ${{ inputs.version }}"
         fi
-        npx cryyer@${{ inputs.cryyer-version }} draft-file \
+        npx @atriumn/cryyer@${{ inputs.cryyer-version }} draft-file \
           --product ${{ inputs.product }} \
           --output "$OUTPUT" \
           --since "$SINCE" \

--- a/.github/actions/send-file/action.yml
+++ b/.github/actions/send-file/action.yml
@@ -87,7 +87,7 @@ runs:
         if [ -n "${{ inputs.audience }}" ]; then
           AUDIENCE_FLAG="--audience ${{ inputs.audience }}"
         fi
-        npx cryyer@${{ inputs.cryyer-version }} send-file \
+        npx @atriumn/cryyer@${{ inputs.cryyer-version }} send-file \
           ${{ inputs.draft-path }} \
           --product ${{ inputs.product }} \
           $DRY_RUN_FLAG \

--- a/.github/workflows/draft-email.yml
+++ b/.github/workflows/draft-email.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           for AUDIENCE in ${{ steps.audiences.outputs.list }}; do
             echo "::group::Drafting for audience: $AUDIENCE"
-            npx cryyer@latest draft-file \
+            npx @atriumn/cryyer@latest draft-file \
               --product cryyer \
               --version "${{ steps.version.outputs.value }}" \
               --since "${{ steps.version.outputs.since }}" \

--- a/.github/workflows/send-email.yml
+++ b/.github/workflows/send-email.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           for AUDIENCE in ${{ steps.audiences.outputs.list }}; do
             echo "::group::Sending for audience: $AUDIENCE"
-            npx cryyer@latest send-file \
+            npx @atriumn/cryyer@latest send-file \
               "drafts/v${{ steps.version.outputs.value }}-${AUDIENCE}.md" \
               --product cryyer \
               --audience "$AUDIENCE"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ Six distinct entry points, each compiled from `src/` to `dist/`:
 - **`send-on-close.ts`** — Used by `send-update.yml` workflow. Triggered on issue close, parses the draft issue body (`**Subject:** ...\n\n---\n\n<body>`), queries subscriber store (audience-aware via `audience:*` label), sends via configured email provider, posts delivery stats as issue comment.
 - **`draft-file.ts`** — CLI command `cryyer draft-file`. Gathers activity, generates LLM draft, writes a YAML front matter markdown file. Designed for release-triggered pipelines where the draft is committed to a PR branch. Accepts `--product`, `--output`, `--since`, `--repo`, `--audience`, `--version` flags.
 - **`send-file.ts`** — CLI command `cryyer send-file`. Reads a YAML front matter draft file (`---\nsubject: ...\n---\n\n<body>`), loads product config, fetches subscribers, sends emails. Accepts `<path>`, `--product`, `--dry-run`, `--audience` flags. Designed for post-release email delivery.
-- **`mcp.ts`** — MCP server for Claude Desktop. Exposes 9 tools (list/get/update/send/regenerate drafts, list products, list/add/remove subscribers) and 1 prompt (`review_drafts`). Uses stdio transport. Run via `node dist/mcp.js` or `npx cryyer-mcp`.
+- **`mcp.ts`** — MCP server for Claude Desktop. Exposes 9 tools (list/get/update/send/regenerate drafts, list products, list/add/remove subscribers) and 1 prompt (`review_drafts`). Uses stdio transport. Run via `node dist/mcp.js` or `npx @atriumn/cryyer-mcp`.
 
 Key modules:
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   <a href="https://github.com/atriumn/cryyer/actions/workflows/ci.yml"><img src="https://github.com/atriumn/cryyer/actions/workflows/ci.yml/badge.svg" alt="CI Status"></a>
-  <a href="https://www.npmjs.com/package/cryyer"><img src="https://img.shields.io/npm/v/cryyer.svg" alt="npm version"></a>
+  <a href="https://www.npmjs.com/package/@atriumn/cryyer"><img src="https://img.shields.io/npm/v/@atriumn/cryyer.svg" alt="npm version"></a>
   <a href="./LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="MIT License"></a>
   <a href="./package.json"><img src="https://img.shields.io/badge/node-%3E%3D20-brightgreen.svg" alt="Node.js >= 20"></a>
 </p>
@@ -33,7 +33,7 @@ Cryyer supports two pipelines:
 
 ```bash
 mkdir my-updates && cd my-updates
-npx cryyer init
+npx @atriumn/cryyer init
 ```
 
 The interactive setup walks you through product name, GitHub repo, voice/tone, LLM provider, subscriber store, and API keys — then creates everything you need:
@@ -46,28 +46,28 @@ The interactive setup walks you through product name, GitHub repo, voice/tone, L
 Then:
 
 ```bash
-npx cryyer check         # validate your setup
-npx cryyer run --dry-run  # preview a draft email
+npx @atriumn/cryyer check         # validate your setup
+npx @atriumn/cryyer run --dry-run  # preview a draft email
 ```
 
 When you're ready to run for real:
 
 ```bash
-npx cryyer run          # full pipeline: gather → draft → send
+npx @atriumn/cryyer run          # full pipeline: gather → draft → send
 ```
 
 Or run the two stages separately:
 
 ```bash
-npx cryyer draft        # generate drafts → create GitHub issues
-npx cryyer send         # send emails when a draft issue is closed
+npx @atriumn/cryyer draft        # generate drafts → create GitHub issues
+npx @atriumn/cryyer send         # send emails when a draft issue is closed
 ```
 
 For release-triggered emails, use the file-based commands:
 
 ```bash
-npx cryyer draft-file --product my-app --version 1.2.0  # generate a draft file
-npx cryyer send-file drafts/v1.2.0.md --product my-app  # send from draft file
+npx @atriumn/cryyer draft-file --product my-app --version 1.2.0  # generate a draft file
+npx @atriumn/cryyer send-file drafts/v1.2.0.md --product my-app  # send from draft file
 ```
 
 You can also create `products/*.yaml` files manually — see [Product Configuration](#product-configuration) for all fields, and [`.env.example`](./.env.example) for all environment variables.
@@ -262,7 +262,7 @@ The MCP server uses stdio transport and is available as a separate binary: `cryy
 ### Standalone usage
 
 ```bash
-npx cryyer-mcp
+npx @atriumn/cryyer-mcp
 ```
 
 Or if installed locally:
@@ -281,7 +281,7 @@ Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_
   "mcpServers": {
     "cryyer": {
       "command": "npx",
-      "args": ["cryyer-mcp"],
+      "args": ["@atriumn/cryyer-mcp"],
       "env": {
         "GITHUB_TOKEN": "ghp_...",
         "CRYYER_REPO": "owner/repo",
@@ -301,7 +301,7 @@ Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_
 
 Any MCP client that supports stdio transport can use Cryyer. The generic config is:
 
-- **Command**: `npx cryyer-mcp` (or `node /path/to/cryyer/dist/mcp.js`)
+- **Command**: `npx @atriumn/cryyer-mcp` (or `node /path/to/cryyer/dist/mcp.js`)
 - **Transport**: stdio
 - **Environment variables**: same as above
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cryyer",
+  "name": "@atriumn/cryyer",
   "version": "0.1.14",
   "description": "Automated product update emails with per-product voice powered by LLM drafts",
   "license": "MIT",

--- a/site/src/content/docs/getting-started.mdx
+++ b/site/src/content/docs/getting-started.mdx
@@ -10,7 +10,7 @@ Cryyer sends automated email updates to your users, with per-product voice power
 Run this inside your project repo:
 
 ```bash
-npx cryyer init
+npx @atriumn/cryyer init
 ```
 
 The interactive setup walks you through product name, GitHub repo, voice/tone, LLM provider, subscriber store, and API keys — then creates everything you need:
@@ -24,28 +24,28 @@ The interactive setup walks you through product name, GitHub repo, voice/tone, L
 Then validate and preview:
 
 ```bash
-npx cryyer check         # validate your setup
-npx cryyer run --dry-run  # preview a draft email
+npx @atriumn/cryyer check         # validate your setup
+npx @atriumn/cryyer run --dry-run  # preview a draft email
 ```
 
 When you're ready to run for real:
 
 ```bash
-npx cryyer run            # full pipeline: gather → draft → send
+npx @atriumn/cryyer run            # full pipeline: gather → draft → send
 ```
 
 Or run the two stages separately:
 
 ```bash
-npx cryyer draft          # generate drafts → create GitHub issues
-npx cryyer send           # send emails when a draft issue is closed
+npx @atriumn/cryyer draft          # generate drafts → create GitHub issues
+npx @atriumn/cryyer send           # send emails when a draft issue is closed
 ```
 
 For release-triggered emails, use the file-based commands:
 
 ```bash
-npx cryyer draft-file --product my-app --version 1.2.0  # generate a draft file
-npx cryyer send-file drafts/v1.2.0.md --product my-app  # send from draft file
+npx @atriumn/cryyer draft-file --product my-app --version 1.2.0  # generate a draft file
+npx @atriumn/cryyer send-file drafts/v1.2.0.md --product my-app  # send from draft file
 ```
 
 You can also create `products/*.yaml` files manually — see [Product Configuration](/configuration/product-config) for all fields, and [Environment Variables](/configuration/environment) for all env vars.

--- a/site/src/content/docs/mcp-server.mdx
+++ b/site/src/content/docs/mcp-server.mdx
@@ -63,7 +63,7 @@ You can also run the MCP server via npx without cloning the repo:
   "mcpServers": {
     "cryyer": {
       "command": "npx",
-      "args": ["cryyer-mcp"],
+      "args": ["@atriumn/cryyer-mcp"],
       "env": { ... }
     }
   }

--- a/src/init.ts
+++ b/src/init.ts
@@ -515,7 +515,7 @@ export async function main(): Promise<void> {
       step++;
     }
     if (emailProvider === 'gmail') {
-      console.log(`    ${step}. Authorize Gmail     npx cryyer auth gmail`);
+      console.log(`    ${step}. Authorize Gmail     npx @atriumn/cryyer auth gmail`);
       step++;
     }
     if (subscriberStore === 'json') {
@@ -526,9 +526,9 @@ export async function main(): Promise<void> {
       console.log(`    ${step}. Add subscribers     Add rows to your Google Sheet`);
     }
     step++;
-    console.log(`    ${step}. Validate setup      npx cryyer check`);
+    console.log(`    ${step}. Validate setup      npx @atriumn/cryyer check`);
     step++;
-    console.log(`    ${step}. Preview a draft     npx cryyer run --dry-run`);
+    console.log(`    ${step}. Preview a draft     npx @atriumn/cryyer run --dry-run`);
     console.log('');
     console.log('  Docs: https://cryyer.dev');
     console.log('');


### PR DESCRIPTION
## Summary
- Rename npm package from `cryyer` to `@atriumn/cryyer` to scope under the org
- Update all `npx cryyer` / `npx cryyer-mcp` references to `npx @atriumn/cryyer` / `npx @atriumn/cryyer-mcp`
- Bin names (`cryyer`, `cryyer-mcp`) remain unchanged — CLI commands work the same

## Files changed
- `package.json` — package name
- `.github/workflows/draft-email.yml`, `send-email.yml` — npx calls
- `.github/actions/draft-file/action.yml`, `send-file/action.yml` — npx calls
- `src/init.ts` — user-facing npx references in init output
- `.env.example` — Gmail OAuth comment
- `CLAUDE.md` — MCP server reference
- `README.md` — all npx references + npm badge URL
- `site/src/content/docs/getting-started.mdx` — all npx references
- `site/src/content/docs/mcp-server.mdx` — Claude Desktop config

## Test plan
- [x] `pnpm run typecheck` — clean
- [x] `pnpm test` — 376 tests pass
- [x] Grep for bare `npx cryyer` confirms none remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)