### PR TITLE
fix: build from source in draft-email workflow

### DIFF
--- a/.github/workflows/draft-email.yml
+++ b/.github/workflows/draft-email.yml
@@ -32,6 +32,14 @@ jobs:
           fi
           echo "since=$SINCE" >> "$GITHUB_OUTPUT"
 
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run build
+
       - name: Parse audience IDs
         id: audiences
         run: |
@@ -42,7 +50,7 @@ jobs:
         run: |
           for AUDIENCE in ${{ steps.audiences.outputs.list }}; do
             echo "::group::Drafting for audience: $AUDIENCE"
-            npx @atriumn/cryyer@latest draft-file \
+            node dist/cli.js draft-file \
               --product cryyer \
               --version "${{ steps.version.outputs.value }}" \
               --since "${{ steps.version.outputs.since }}" \


### PR DESCRIPTION
## Summary
- The draft-email workflow was running `npx @atriumn/cryyer@latest` but that package doesn't exist on npm yet (first release under the scoped name)
- Switch to building from source (`pnpm install && pnpm run build && node dist/cli.js`) since the repo is already checked out

This unblocks PR #99 which is failing on the draft check.

## Test plan
- [ ] Merge → release-please re-runs draft-email on #99 → draft job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)