### PR TITLE
feat: add --pipeline flag for weekly/release/both workflow choice

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,13 +52,12 @@ npx @atriumn/cryyer init --yes \
   --product "My App" \
   --repo owner/my-app \
   --voice "Friendly and concise" \
-  --llm gemini \
-  --workflows
+  --pipeline weekly
 ```
 
 Non-interactive mode (`--yes` or `CI=true`) skips all prompts. Secrets are read from environment variables (`ANTHROPIC_API_KEY`, `RESEND_API_KEY`, etc.) instead of being written to `.env`. Defaults: `anthropic` LLM, `json` subscriber store, `resend` email, no workflows.
 
-Available flags: `--product`, `--repo`, `--voice`, `--llm`, `--subscriber-store`, `--email-provider`, `--from-email`, `--workflows`/`--no-workflows`.
+Available flags: `--product`, `--repo`, `--voice`, `--llm`, `--subscriber-store`, `--email-provider`, `--from-email`, `--pipeline` (`weekly`, `release`, or `both`).
 
 ### For agents — write files directly
 

--- a/site/src/content/docs/getting-started.mdx
+++ b/site/src/content/docs/getting-started.mdx
@@ -30,13 +30,12 @@ npx @atriumn/cryyer init --yes \
   --product "My App" \
   --repo owner/my-app \
   --voice "Friendly and concise" \
-  --llm gemini \
-  --workflows
+  --pipeline weekly
 ```
 
 Non-interactive mode (`--yes` or `CI=true`) skips all prompts. Secrets are read from environment variables (`ANTHROPIC_API_KEY`, `RESEND_API_KEY`, etc.) instead of being written to `.env`. Defaults: `anthropic` LLM, `json` subscriber store, `resend` email, no workflows.
 
-Available flags: `--product`, `--repo`, `--voice`, `--llm`, `--subscriber-store`, `--email-provider`, `--from-email`, `--workflows`/`--no-workflows`.
+Available flags: `--product`, `--repo`, `--voice`, `--llm`, `--subscriber-store`, `--email-provider`, `--from-email`, `--pipeline` (`weekly`, `release`, or `both`).
 
 ### For agents — write files directly
 

--- a/src/__tests__/init-workflows.test.ts
+++ b/src/__tests__/init-workflows.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildDraftWorkflowContent, buildSendWorkflowContent } from '../init.js';
+import { buildDraftWorkflowContent, buildSendWorkflowContent, buildWeeklyDraftWorkflowContent, buildSendUpdateWorkflowContent } from '../init.js';
 
 describe('buildDraftWorkflowContent', () => {
   it('generates valid YAML with correct structure', () => {
@@ -123,5 +123,76 @@ describe('buildSendWorkflowContent', () => {
   it('includes FROM_EMAIL secret', () => {
     const content = buildSendWorkflowContent('acme-cli', 'resend', 'json');
     expect(content).toContain('secrets.FROM_EMAIL');
+  });
+});
+
+describe('buildWeeklyDraftWorkflowContent', () => {
+  it('generates valid YAML with cron schedule', () => {
+    const content = buildWeeklyDraftWorkflowContent('acme-cli', 'anthropic');
+    expect(content).toContain('name: Weekly Draft');
+    expect(content).toContain('schedule:');
+    expect(content).toContain('workflow_dispatch:');
+  });
+
+  it('uses npx @atriumn/cryyer@latest draft', () => {
+    const content = buildWeeklyDraftWorkflowContent('acme-cli', 'anthropic');
+    expect(content).toContain('npx @atriumn/cryyer@latest draft');
+  });
+
+  it('uses correct LLM secret for provider', () => {
+    expect(buildWeeklyDraftWorkflowContent('app', 'anthropic')).toContain('ANTHROPIC_API_KEY');
+    expect(buildWeeklyDraftWorkflowContent('app', 'openai')).toContain('OPENAI_API_KEY');
+    expect(buildWeeklyDraftWorkflowContent('app', 'gemini')).toContain('GEMINI_API_KEY');
+  });
+
+  it('sets CRYYER_REPO to github.repository', () => {
+    const content = buildWeeklyDraftWorkflowContent('acme-cli', 'anthropic');
+    expect(content).toContain('CRYYER_REPO: ${{ github.repository }}');
+  });
+});
+
+describe('buildSendUpdateWorkflowContent', () => {
+  it('generates valid YAML that triggers on issue close', () => {
+    const content = buildSendUpdateWorkflowContent('acme-cli', 'resend', 'json');
+    expect(content).toContain('name: Send Update');
+    expect(content).toContain('issues:');
+    expect(content).toContain("types: [closed]");
+    expect(content).toContain("contains(github.event.issue.labels.*.name, 'draft')");
+  });
+
+  it('uses npx @atriumn/cryyer@latest send-on-close', () => {
+    const content = buildSendUpdateWorkflowContent('acme-cli', 'resend', 'json');
+    expect(content).toContain('npx @atriumn/cryyer@latest send-on-close');
+  });
+
+  it('includes resend credentials for resend provider', () => {
+    const content = buildSendUpdateWorkflowContent('acme-cli', 'resend', 'json');
+    expect(content).toContain('RESEND_API_KEY');
+    expect(content).not.toContain('GMAIL_REFRESH_TOKEN');
+  });
+
+  it('includes gmail credentials for gmail provider', () => {
+    const content = buildSendUpdateWorkflowContent('acme-cli', 'gmail', 'json');
+    expect(content).toContain('GMAIL_REFRESH_TOKEN');
+    expect(content).not.toContain('RESEND_API_KEY');
+  });
+
+  it('includes supabase credentials for supabase store', () => {
+    const content = buildSendUpdateWorkflowContent('acme-cli', 'resend', 'supabase');
+    expect(content).toContain('SUPABASE_URL');
+    expect(content).toContain('SUPABASE_SERVICE_KEY');
+  });
+
+  it('includes google sheets credentials for google-sheets store', () => {
+    const content = buildSendUpdateWorkflowContent('acme-cli', 'resend', 'google-sheets');
+    expect(content).toContain('GOOGLE_SHEETS_SPREADSHEET_ID');
+    expect(content).toContain('GOOGLE_SERVICE_ACCOUNT_EMAIL');
+    expect(content).toContain('GOOGLE_PRIVATE_KEY');
+  });
+
+  it('includes ISSUE_NUMBER and FROM_EMAIL', () => {
+    const content = buildSendUpdateWorkflowContent('acme-cli', 'resend', 'json');
+    expect(content).toContain('ISSUE_NUMBER');
+    expect(content).toContain('FROM_EMAIL');
   });
 });

--- a/src/__tests__/init.test.ts
+++ b/src/__tests__/init.test.ts
@@ -32,7 +32,7 @@ describe('parseInitFlags', () => {
       '--email-provider', 'gmail',
       '--from-email', 'hi@acme.dev',
       '--yes',
-      '--workflows',
+      '--pipeline', 'weekly',
     ]);
     expect(flags).toEqual({
       product: 'My App',
@@ -43,7 +43,7 @@ describe('parseInitFlags', () => {
       emailProvider: 'gmail',
       fromEmail: 'hi@acme.dev',
       yes: true,
-      workflows: true,
+      pipeline: 'weekly',
     });
   });
 
@@ -51,8 +51,18 @@ describe('parseInitFlags', () => {
     expect(parseInitFlags(['-y']).yes).toBe(true);
   });
 
-  it('parses --no-workflows', () => {
-    expect(parseInitFlags(['--no-workflows']).workflows).toBe(false);
+  it('parses --pipeline with all valid values', () => {
+    expect(parseInitFlags(['--pipeline', 'weekly']).pipeline).toBe('weekly');
+    expect(parseInitFlags(['--pipeline', 'release']).pipeline).toBe('release');
+    expect(parseInitFlags(['--pipeline', 'both']).pipeline).toBe('both');
+  });
+
+  it('throws on invalid --pipeline value', () => {
+    expect(() => parseInitFlags(['--pipeline', 'invalid'])).toThrow('Invalid pipeline');
+  });
+
+  it('--workflows back-compat maps to release', () => {
+    expect(parseInitFlags(['--workflows']).pipeline).toBe('release');
   });
 
   it('returns empty flags for no arguments', () => {
@@ -242,8 +252,8 @@ describe('main (init)', () => {
     'ghp_test',           // github token
     're_test',            // resend key
     'updates@acme.dev',   // from email
-    // Workflow setup
-    'Y',                  // set up workflows
+    // Pipeline setup
+    '1',                  // weekly pipeline (default)
   ];
 
   function setupFreshDir() {
@@ -493,7 +503,7 @@ describe('main (init)', () => {
     expect(envContent).not.toContain('RESEND_API_KEY');
   });
 
-  it('creates workflow files when user opts in', async () => {
+  it('creates weekly workflow files when user selects weekly pipeline', async () => {
     setupFreshDir();
     makeRl(freshAnswers);
 
@@ -505,17 +515,17 @@ describe('main (init)', () => {
       { recursive: true }
     );
 
-    // draft-email.yml
+    // weekly-draft.yml
     expect(writeFileSync).toHaveBeenCalledWith(
-      expect.stringContaining('draft-email.yml'),
-      expect.stringContaining('atriumn/cryyer/.github/actions/draft-file@v0'),
+      expect.stringContaining('weekly-draft.yml'),
+      expect.stringContaining('Weekly Draft'),
       'utf-8'
     );
 
-    // send-email.yml
+    // send-update.yml
     expect(writeFileSync).toHaveBeenCalledWith(
-      expect.stringContaining('send-email.yml'),
-      expect.stringContaining('atriumn/cryyer/.github/actions/send-file@v0'),
+      expect.stringContaining('send-update.yml'),
+      expect.stringContaining('Send Update'),
       'utf-8'
     );
   });
@@ -636,9 +646,9 @@ describe('main (non-interactive)', () => {
     expect(envCalls).toHaveLength(0);
   });
 
-  it('creates workflows when --workflows is passed', async () => {
+  it('creates release workflows with --pipeline release', async () => {
     setupFreshDir();
-    setArgv('-y', '--product', 'Acme', '--repo', 'acme/cli', '--voice', 'Casual', '--workflows');
+    setArgv('-y', '--product', 'Acme', '--repo', 'acme/cli', '--voice', 'Casual', '--pipeline', 'release');
 
     await main();
 
@@ -654,6 +664,60 @@ describe('main (non-interactive)', () => {
     expect(writeFileSync).toHaveBeenCalledWith(
       expect.stringContaining('send-email.yml'),
       expect.stringContaining('atriumn/cryyer'),
+      'utf-8'
+    );
+  });
+
+  it('creates weekly workflows with --pipeline weekly', async () => {
+    setupFreshDir();
+    setArgv('-y', '--product', 'Acme', '--repo', 'acme/cli', '--voice', 'Casual', '--pipeline', 'weekly');
+
+    await main();
+
+    expect(writeFileSync).toHaveBeenCalledWith(
+      expect.stringContaining('weekly-draft.yml'),
+      expect.stringContaining('Weekly Draft'),
+      'utf-8'
+    );
+    expect(writeFileSync).toHaveBeenCalledWith(
+      expect.stringContaining('send-update.yml'),
+      expect.stringContaining('Send Update'),
+      'utf-8'
+    );
+    // Should NOT create release workflows
+    const releaseCalls = (writeFileSync as Mock).mock.calls.filter(
+      (call) => typeof call[0] === 'string' && call[0].includes('draft-email.yml')
+    );
+    expect(releaseCalls).toHaveLength(0);
+  });
+
+  it('creates both pipelines with --pipeline both', async () => {
+    setupFreshDir();
+    setArgv('-y', '--product', 'Acme', '--repo', 'acme/cli', '--voice', 'Casual', '--pipeline', 'both');
+
+    await main();
+
+    expect(writeFileSync).toHaveBeenCalledWith(
+      expect.stringContaining('weekly-draft.yml'),
+      expect.any(String),
+      'utf-8'
+    );
+    expect(writeFileSync).toHaveBeenCalledWith(
+      expect.stringContaining('draft-email.yml'),
+      expect.any(String),
+      'utf-8'
+    );
+  });
+
+  it('--workflows back-compat maps to release pipeline', async () => {
+    setupFreshDir();
+    setArgv('-y', '--product', 'Acme', '--repo', 'acme/cli', '--voice', 'Casual', '--workflows');
+
+    await main();
+
+    expect(writeFileSync).toHaveBeenCalledWith(
+      expect.stringContaining('draft-email.yml'),
+      expect.any(String),
       'utf-8'
     );
   });
@@ -681,7 +745,7 @@ describe('main (non-interactive)', () => {
 
   it('respects --llm flag', async () => {
     setupFreshDir();
-    setArgv('-y', '--product', 'Acme', '--repo', 'acme/cli', '--voice', 'Casual', '--llm', 'gemini', '--workflows');
+    setArgv('-y', '--product', 'Acme', '--repo', 'acme/cli', '--voice', 'Casual', '--llm', 'gemini', '--pipeline', 'release');
 
     await main();
 

--- a/src/init.ts
+++ b/src/init.ts
@@ -255,6 +255,91 @@ jobs:
 `;
 }
 
+export function buildWeeklyDraftWorkflowContent(productId: string, llmProvider: string): string {
+  const secretName = LLM_KEY_NAMES[llmProvider] ?? 'ANTHROPIC_API_KEY';
+  return `name: Weekly Draft
+
+on:
+  schedule:
+    - cron: '0 13 * * 1'  # Monday 1pm UTC
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  draft:
+    name: Generate Weekly Draft
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npx @atriumn/cryyer@latest draft
+        env:
+          GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}
+          CRYYER_REPO: \${{ github.repository }}
+          LLM_PROVIDER: ${llmProvider}
+          ${secretName}: \${{ secrets.${secretName} }}
+`;
+}
+
+export function buildSendUpdateWorkflowContent(
+  productId: string,
+  emailProvider: string,
+  subscriberStore: string,
+): string {
+  const envLines: string[] = [
+    `          GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}`,
+    `          FROM_EMAIL: \${{ secrets.FROM_EMAIL }}`,
+    `          EMAIL_PROVIDER: ${emailProvider}`,
+    `          ISSUE_NUMBER: \${{ github.event.issue.number }}`,
+    `          SUBSCRIBER_STORE: ${subscriberStore}`,
+  ];
+
+  if (emailProvider === 'resend') {
+    envLines.push(`          RESEND_API_KEY: \${{ secrets.RESEND_API_KEY }}`);
+  } else if (emailProvider === 'gmail') {
+    envLines.push(`          GMAIL_REFRESH_TOKEN: \${{ secrets.GMAIL_REFRESH_TOKEN }}`);
+  }
+
+  if (subscriberStore === 'supabase') {
+    envLines.push(`          SUPABASE_URL: \${{ secrets.SUPABASE_URL }}`);
+    envLines.push(`          SUPABASE_SERVICE_KEY: \${{ secrets.SUPABASE_SERVICE_KEY }}`);
+  } else if (subscriberStore === 'google-sheets') {
+    envLines.push(`          GOOGLE_SHEETS_SPREADSHEET_ID: \${{ secrets.GOOGLE_SHEETS_SPREADSHEET_ID }}`);
+    envLines.push(`          GOOGLE_SERVICE_ACCOUNT_EMAIL: \${{ secrets.GOOGLE_SERVICE_ACCOUNT_EMAIL }}`);
+    envLines.push(`          GOOGLE_PRIVATE_KEY: \${{ secrets.GOOGLE_PRIVATE_KEY }}`);
+  }
+
+  return `name: Send Update
+
+on:
+  issues:
+    types: [closed]
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  send:
+    name: Send Email Update
+    runs-on: ubuntu-latest
+    if: contains(github.event.issue.labels.*.name, 'draft')
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npx @atriumn/cryyer@latest send-on-close
+        env:
+${envLines.join('\n')}
+`;
+}
+
 function parseSelection(raw: string, options: readonly string[], defaultIndex: number): string {
   const trimmed = raw.trim();
   if (!trimmed) return options[defaultIndex];
@@ -262,6 +347,9 @@ function parseSelection(raw: string, options: readonly string[], defaultIndex: n
   if (num >= 1 && num <= options.length) return options[num - 1];
   throw new Error(`Invalid selection: "${trimmed}". Enter a number 1-${options.length}.`);
 }
+
+const PIPELINES = ['weekly', 'release', 'both'] as const;
+type Pipeline = typeof PIPELINES[number];
 
 export interface InitFlags {
   product?: string;
@@ -272,7 +360,7 @@ export interface InitFlags {
   emailProvider?: string;
   fromEmail?: string;
   yes?: boolean;
-  workflows?: boolean;
+  pipeline?: Pipeline;
 }
 
 export function parseInitFlags(argv: string[]): InitFlags {
@@ -289,8 +377,18 @@ export function parseInitFlags(argv: string[]): InitFlags {
       case '--email-provider': flags.emailProvider = next; i++; break;
       case '--from-email': flags.fromEmail = next; i++; break;
       case '--yes': case '-y': flags.yes = true; break;
-      case '--no-workflows': flags.workflows = false; break;
-      case '--workflows': flags.workflows = true; break;
+      case '--pipeline': {
+        const val = next as Pipeline;
+        if (!PIPELINES.includes(val)) {
+          throw new Error(`Invalid pipeline: "${next}". Must be one of: ${PIPELINES.join(', ')}`);
+        }
+        flags.pipeline = val;
+        i++;
+        break;
+      }
+      // Back-compat: --workflows maps to --pipeline release, --no-workflows skips
+      case '--workflows': flags.pipeline = flags.pipeline ?? 'release'; break;
+      case '--no-workflows': if (!flags.pipeline) flags.pipeline = undefined; break;
     }
   }
   return flags;
@@ -541,41 +639,82 @@ export async function main(): Promise<void> {
     }
 
     // --- Phase 6: GitHub Actions workflows ---
-    let setupWorkflows: boolean;
-    if (flags.workflows !== undefined) {
-      setupWorkflows = flags.workflows;
+    let pipeline: Pipeline | undefined;
+    if (flags.pipeline !== undefined) {
+      pipeline = flags.pipeline;
     } else if (nonInteractive) {
-      setupWorkflows = false;
+      pipeline = undefined; // no workflows by default in non-interactive
     } else {
-      const rawSetupWorkflows = await ask('? Set up GitHub Actions for release-triggered emails? (Y/n): ');
-      setupWorkflows = rawSetupWorkflows.trim().toLowerCase() !== 'n';
+      const pipelinePrompt = '? Set up GitHub Actions? (1=Weekly digest, 2=Release emails, 3=Both, n=Skip) [1]: ';
+      const rawPipeline = await ask(pipelinePrompt);
+      const trimmed = rawPipeline.trim().toLowerCase();
+      if (trimmed === 'n' || trimmed === 'skip') {
+        pipeline = undefined;
+      } else if (trimmed === '' || trimmed === '1') {
+        pipeline = 'weekly';
+      } else if (trimmed === '2') {
+        pipeline = 'release';
+      } else if (trimmed === '3') {
+        pipeline = 'both';
+      } else {
+        pipeline = undefined;
+      }
     }
     const workflowSecrets: string[] = [];
 
-    if (setupWorkflows) {
+    if (pipeline) {
       const workflowsDir = join(cwd, '.github', 'workflows');
       mkdirSync(workflowsDir, { recursive: true });
 
-      const draftWorkflowPath = join(workflowsDir, 'draft-email.yml');
-      let writeDraftWorkflow = true;
-      if (existsSync(draftWorkflowPath) && !nonInteractive) {
-        const rawOverwrite = await ask('  draft-email.yml already exists. Overwrite? (y/N): ');
-        writeDraftWorkflow = rawOverwrite.trim().toLowerCase() === 'y';
-      }
-      if (writeDraftWorkflow) {
-        writeFileSync(draftWorkflowPath, buildDraftWorkflowContent(productId, llmProvider), 'utf-8');
-        created.push(['.github/workflows/draft-email.yml', 'Draft email on release PR']);
+      const wantsWeekly = pipeline === 'weekly' || pipeline === 'both';
+      const wantsRelease = pipeline === 'release' || pipeline === 'both';
+
+      if (wantsWeekly) {
+        const weeklyDraftPath = join(workflowsDir, 'weekly-draft.yml');
+        let writeIt = true;
+        if (existsSync(weeklyDraftPath) && !nonInteractive) {
+          const raw = await ask('  weekly-draft.yml already exists. Overwrite? (y/N): ');
+          writeIt = raw.trim().toLowerCase() === 'y';
+        }
+        if (writeIt) {
+          writeFileSync(weeklyDraftPath, buildWeeklyDraftWorkflowContent(productId, llmProvider), 'utf-8');
+          created.push(['.github/workflows/weekly-draft.yml', 'Weekly draft on cron + manual trigger']);
+        }
+
+        const sendUpdatePath = join(workflowsDir, 'send-update.yml');
+        let writeSend = true;
+        if (existsSync(sendUpdatePath) && !nonInteractive) {
+          const raw = await ask('  send-update.yml already exists. Overwrite? (y/N): ');
+          writeSend = raw.trim().toLowerCase() === 'y';
+        }
+        if (writeSend) {
+          writeFileSync(sendUpdatePath, buildSendUpdateWorkflowContent(productId, emailProvider, subscriberStore), 'utf-8');
+          created.push(['.github/workflows/send-update.yml', 'Send email when draft issue closed']);
+        }
       }
 
-      const sendWorkflowPath = join(workflowsDir, 'send-email.yml');
-      let writeSendWorkflow = true;
-      if (existsSync(sendWorkflowPath) && !nonInteractive) {
-        const rawOverwrite = await ask('  send-email.yml already exists. Overwrite? (y/N): ');
-        writeSendWorkflow = rawOverwrite.trim().toLowerCase() === 'y';
-      }
-      if (writeSendWorkflow) {
-        writeFileSync(sendWorkflowPath, buildSendWorkflowContent(productId, emailProvider, subscriberStore), 'utf-8');
-        created.push(['.github/workflows/send-email.yml', 'Send email on release']);
+      if (wantsRelease) {
+        const draftWorkflowPath = join(workflowsDir, 'draft-email.yml');
+        let writeDraftWorkflow = true;
+        if (existsSync(draftWorkflowPath) && !nonInteractive) {
+          const rawOverwrite = await ask('  draft-email.yml already exists. Overwrite? (y/N): ');
+          writeDraftWorkflow = rawOverwrite.trim().toLowerCase() === 'y';
+        }
+        if (writeDraftWorkflow) {
+          writeFileSync(draftWorkflowPath, buildDraftWorkflowContent(productId, llmProvider), 'utf-8');
+          created.push(['.github/workflows/draft-email.yml', 'Draft email on release PR']);
+        }
+
+        const sendWorkflowPath = join(workflowsDir, 'send-email.yml');
+        let writeSendWorkflow = true;
+        if (existsSync(sendWorkflowPath) && !nonInteractive) {
+          const rawOverwrite = await ask('  send-email.yml already exists. Overwrite? (y/N): ');
+          writeSendWorkflow = rawOverwrite.trim().toLowerCase() === 'y';
+        }
+        if (writeSendWorkflow) {
+          writeFileSync(sendWorkflowPath, buildSendWorkflowContent(productId, emailProvider, subscriberStore), 'utf-8');
+          created.push(['.github/workflows/send-email.yml', 'Send email on release']);
+        }
       }
 
       workflowSecrets.push(LLM_KEY_NAMES[llmProvider]);


### PR DESCRIPTION
## Summary
- Replace `--workflows`/`--no-workflows` with `--pipeline weekly|release|both`
- Interactive prompt now offers: `1=Weekly digest` (default), `2=Release emails`, `3=Both`, `n=Skip`
- Weekly pipeline scaffolds `weekly-draft.yml` + `send-update.yml` (no versioning needed)
- Release pipeline scaffolds `draft-email.yml` + `send-email.yml` (requires tags/releases)
- `--workflows` still works as back-compat (maps to `release`)
- New builders: `buildWeeklyDraftWorkflowContent`, `buildSendUpdateWorkflowContent`

Closes #105

## Test plan
- [x] `pnpm run typecheck` — clean
- [x] `CI=true pnpm test` — 406 passing
- [ ] `npx @atriumn/cryyer init` — interactive pipeline prompt works
- [ ] `npx @atriumn/cryyer init --yes --product test --repo o/r --voice casual --pipeline weekly` — scaffolds weekly workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)