### PR TITLE
feat: add GitHub Gist subscriber store

### DIFF
--- a/.github/actions/send-file/action.yml
+++ b/.github/actions/send-file/action.yml
@@ -26,7 +26,7 @@ inputs:
     required: false
     default: Cryyer Updates
   subscriber-store:
-    description: Subscriber store (json, supabase, google-sheets)
+    description: Subscriber store (json, supabase, google-sheets, gist)
     required: false
     default: json
   supabase-url:
@@ -44,6 +44,13 @@ inputs:
   google-private-key:
     description: Google service account private key (required when subscriber-store is google-sheets)
     required: false
+  github-gist-id:
+    description: Gist ID for subscriber storage (required when subscriber-store is gist)
+    required: false
+  github-token:
+    description: GitHub token for gist access (required when subscriber-store is gist)
+    required: false
+    default: ${{ github.token }}
   audience:
     description: Audience ID for multi-audience products
     required: false
@@ -78,6 +85,8 @@ runs:
         GOOGLE_SHEETS_SPREADSHEET_ID: ${{ inputs.google-sheets-spreadsheet-id }}
         GOOGLE_SERVICE_ACCOUNT_EMAIL: ${{ inputs.google-service-account-email }}
         GOOGLE_PRIVATE_KEY: ${{ inputs.google-private-key }}
+        GITHUB_GIST_ID: ${{ inputs.github-gist-id }}
+        GITHUB_TOKEN: ${{ inputs.github-token }}
       run: |
         DRY_RUN_FLAG=""
         if [ "${{ inputs.dry-run }}" = "true" ]; then

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ Key modules:
 | `gather.ts` | Fetches merged PRs, releases, fallback commits via Octokit (`gatherActivity`); filters bots |
 | `llm-provider.ts` | LLMProvider interface and factory; adapters for Anthropic, OpenAI, Gemini |
 | `summarize.ts` | Builds prompt with product voice, calls LLM provider, parses JSON `{subject, body}` response |
-| `subscriber-store.ts` | SubscriberStore interface and factory; adapters for Supabase, JSON file, Google Sheets. Supports `getSubscribers`, `recordEmailSent`, `addSubscriber`, `removeSubscriber`. |
+| `subscriber-store.ts` | SubscriberStore interface and factory; adapters for Supabase, JSON file, GitHub Gist, Google Sheets. Supports `getSubscribers`, `recordEmailSent`, `addSubscriber`, `removeSubscriber`. |
 | `mcp.ts` | MCP server entry point; 9 tools + 1 prompt for draft review and subscriber management |
 | `email-provider.ts` | EmailProvider interface and factory; adapters for Resend, Gmail |
 | `auth.ts` | `cryyer auth gmail` — OAuth 2.0 flow for Gmail authorization |
@@ -148,12 +148,15 @@ GMAIL_REFRESH_TOKEN  # Required when EMAIL_PROVIDER=gmail; set via "cryyer auth 
 ### Subscriber Store Configuration
 
 ```
-SUBSCRIBER_STORE             # "supabase" (default), "json", or "google-sheets"
+SUBSCRIBER_STORE             # "supabase" (default), "json", "gist", or "google-sheets"
 # Supabase (default):
 SUPABASE_URL, SUPABASE_SERVICE_KEY
 # JSON file:
 SUBSCRIBERS_JSON_PATH        # Default: ./subscribers.json
 EMAIL_LOG_JSON_PATH          # Default: ./email-log.json
+# GitHub Gist (private storage for public repos):
+GITHUB_GIST_ID               # Gist ID containing subscribers.json
+GITHUB_TOKEN                 # Already available in GitHub Actions
 # Google Sheets:
 GOOGLE_SHEETS_SPREADSHEET_ID
 GOOGLE_SERVICE_ACCOUNT_EMAIL

--- a/site/src/content/docs/configuration/environment.mdx
+++ b/site/src/content/docs/configuration/environment.mdx
@@ -42,7 +42,7 @@ See [LLM Providers](/llm-providers) for setup details.
 
 | Variable | Default | Description |
 |---|---|---|
-| `SUBSCRIBER_STORE` | `supabase` | `supabase`, `json`, or `google-sheets` |
+| `SUBSCRIBER_STORE` | `supabase` | `supabase`, `json`, `gist`, or `google-sheets` |
 
 ### Supabase
 
@@ -57,6 +57,13 @@ See [LLM Providers](/llm-providers) for setup details.
 |---|---|---|
 | `SUBSCRIBERS_JSON_PATH` | `./subscribers.json` | Path to subscriber data |
 | `EMAIL_LOG_JSON_PATH` | `./email-log.json` | Path to email send log |
+
+### GitHub Gist
+
+| Variable | Description |
+|---|---|
+| `GITHUB_GIST_ID` | ID of a private Gist containing `subscribers.json` |
+| `GITHUB_TOKEN` | GitHub token with gist scope (automatic in Actions) |
 
 ### Google Sheets
 

--- a/site/src/content/docs/github-actions/composite-actions.mdx
+++ b/site/src/content/docs/github-actions/composite-actions.mdx
@@ -57,12 +57,14 @@ Reads a YAML front matter draft file, loads product config, fetches subscribers,
 | `email-api-key` | no | — | Resend API key |
 | `gmail-refresh-token` | no | — | Gmail OAuth refresh token |
 | `from-name` | no | `Cryyer Updates` | Sender display name |
-| `subscriber-store` | no | `json` | Subscriber store (`json`, `supabase`, `google-sheets`) |
+| `subscriber-store` | no | `json` | Subscriber store (`json`, `gist`, `supabase`, `google-sheets`) |
 | `supabase-url` | no | — | Supabase project URL |
 | `supabase-service-key` | no | — | Supabase service role key |
 | `google-sheets-spreadsheet-id` | no | — | Google Sheets spreadsheet ID |
 | `google-service-account-email` | no | — | Google service account email |
 | `google-private-key` | no | — | Google service account private key |
+| `github-gist-id` | no | — | Gist ID for subscriber storage |
+| `github-token` | no | `github.token` | GitHub token for gist access |
 | `audience` | no | — | Audience ID for multi-audience products |
 | `dry-run` | no | `false` | Preview without sending |
 | `cryyer-version` | no | `latest` | Cryyer npm package version |

--- a/site/src/content/docs/subscriber-stores/gist.mdx
+++ b/site/src/content/docs/subscriber-stores/gist.mdx
@@ -1,0 +1,101 @@
+---
+title: GitHub Gist Store
+description: Use a private GitHub Gist for subscriber data.
+---
+
+Store subscribers in a **private GitHub Gist** — ideal for public repos where you can't commit a `subscribers.json` file without exposing email addresses.
+
+## Why use this?
+
+The [JSON file store](/subscriber-stores/json) requires `subscribers.json` to be checked into the repo so GitHub Actions can read it. In a **public repo**, that means subscriber emails are visible to anyone. The Gist store solves this by keeping the same JSON format in a private Gist that's only accessible via the GitHub API with a token.
+
+## Setup
+
+### 1. Create a private Gist
+
+Create a [new secret Gist](https://gist.github.com/) with a file named `subscribers.json`:
+
+```json
+[]
+```
+
+Copy the Gist ID from the URL (e.g., `https://gist.github.com/yourname/abc123def456` → `abc123def456`).
+
+### 2. Add the Gist ID as a repository secret
+
+```bash
+gh secret set SUBSCRIBERS_GIST_ID --body "abc123def456"
+```
+
+### 3. Set environment variables
+
+```bash
+export SUBSCRIBER_STORE=gist
+export GITHUB_GIST_ID=abc123def456
+export GITHUB_TOKEN=ghp_...
+```
+
+In GitHub Actions, `GITHUB_TOKEN` is already available automatically.
+
+## Configuration
+
+| Variable | Required | Description |
+|---|---|---|
+| `GITHUB_GIST_ID` | Yes | ID of the private Gist |
+| `GITHUB_TOKEN` | Yes | GitHub token with `gist` scope (automatic in Actions) |
+
+## File format
+
+The Gist uses the same JSON format as the [JSON file store](/subscriber-stores/json):
+
+```json
+[
+  {
+    "email": "alice@example.com",
+    "name": "Alice",
+    "productIds": ["my-app", "other-app"]
+  },
+  {
+    "email": "bob@example.com",
+    "productIds": ["my-app"]
+  }
+]
+```
+
+[Audience](/configuration/product-config#audiences) compound keys work the same way:
+
+```json
+[
+  {
+    "email": "alice@example.com",
+    "productIds": ["my-app:beta"]
+  }
+]
+```
+
+## Email logging
+
+Sent emails are logged to an `email-log.json` file in the same Gist (created automatically on first send).
+
+## GitHub Actions usage
+
+```yaml
+- uses: atriumn/cryyer/.github/actions/send-file@v0
+  with:
+    product: my-app
+    draft-path: drafts/v1.2.0.md
+    from-email: updates@yourdomain.com
+    email-api-key: ${{ secrets.RESEND_API_KEY }}
+    subscriber-store: gist
+    github-gist-id: ${{ secrets.SUBSCRIBERS_GIST_ID }}
+```
+
+The `github-token` input defaults to `${{ github.token }}`, which already has gist access in Actions.
+
+## Managing subscribers
+
+You can manage subscribers through any of the standard Cryyer interfaces:
+
+- **MCP tools**: `add_subscriber`, `remove_subscriber`, `list_subscribers`
+- **Directly**: Edit the Gist at `https://gist.github.com/{id}`
+- **GitHub CLI**: `gh gist edit {id}`

--- a/site/src/content/docs/subscriber-stores/index.mdx
+++ b/site/src/content/docs/subscriber-stores/index.mdx
@@ -3,11 +3,12 @@ title: Subscriber Stores
 description: Choose where Cryyer reads subscriber data from.
 ---
 
-Cryyer supports three subscriber store backends. Set the `SUBSCRIBER_STORE` environment variable to choose yours. Default is `supabase`.
+Cryyer supports four subscriber store backends. Set the `SUBSCRIBER_STORE` environment variable to choose yours. Default is `supabase`.
 
 | Store | Best for | Features |
 |---|---|---|
 | [JSON File](/subscriber-stores/json) | Local dev, small lists | Simplest setup, file-based |
+| [GitHub Gist](/subscriber-stores/gist) | Public repos, small lists | Private storage, no extra services |
 | [Supabase](/subscriber-stores/supabase) | Production, dynamic lists | Full CRUD, email logging |
 | [Google Sheets](/subscriber-stores/google-sheets) | Non-technical teams | Spreadsheet UI, easy sharing |
 
@@ -29,6 +30,9 @@ When using [audiences](/configuration/product-config#audiences), subscriber look
 ```bash
 # JSON (simplest)
 SUBSCRIBER_STORE=json
+
+# GitHub Gist (private storage for public repos)
+SUBSCRIBER_STORE=gist
 
 # Supabase (default, production-ready)
 SUBSCRIBER_STORE=supabase

--- a/site/src/content/docs/subscriber-stores/json.mdx
+++ b/site/src/content/docs/subscriber-stores/json.mdx
@@ -5,6 +5,10 @@ description: Use a local JSON file for subscriber data.
 
 The simplest subscriber store — perfect for local development and small lists.
 
+:::caution[Public repos]
+In a public repo, `subscribers.json` must be committed for GitHub Actions to read it, which exposes subscriber emails. Use the [GitHub Gist store](/subscriber-stores/gist) instead — it keeps the same JSON format in a private Gist.
+:::
+
 ## Setup
 
 ```bash

--- a/src/__tests__/subscriber-store.test.ts
+++ b/src/__tests__/subscriber-store.test.ts
@@ -8,6 +8,20 @@ vi.mock('@supabase/supabase-js', () => ({
   createClient: vi.fn(() => ({ from: mockFrom })),
 }));
 
+// --- Octokit / Gist mocks ---
+const mockGistGet = vi.fn();
+const mockGistUpdate = vi.fn();
+vi.mock('octokit', () => ({
+  Octokit: class MockOctokit {
+    rest = {
+      gists: {
+        get: mockGistGet,
+        update: mockGistUpdate,
+      },
+    };
+  },
+}));
+
 // --- Google Sheets mocks ---
 const mockAddRow = vi.fn();
 const mockSheetsByTitle: Record<string, unknown> = {};
@@ -29,7 +43,7 @@ vi.mock('google-auth-library', () => ({
   },
 }));
 
-import { createSubscriberStore, SupabaseStore, JsonFileStore, GoogleSheetsStore } from '../subscriber-store.js';
+import { createSubscriberStore, SupabaseStore, JsonFileStore, GoogleSheetsStore, GistStore } from '../subscriber-store.js';
 
 describe('createSubscriberStore', () => {
   const originalEnv = { ...process.env };
@@ -552,5 +566,180 @@ describe('GoogleSheetsStore', () => {
     await store.removeSubscriber('my-app', 'nonexistent@test.com');
 
     expect(mockRows[0].save).not.toHaveBeenCalled();
+  });
+});
+
+describe('createSubscriberStore gist', () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('creates GistStore when SUBSCRIBER_STORE=gist', () => {
+    process.env.SUBSCRIBER_STORE = 'gist';
+    process.env.GITHUB_GIST_ID = 'abc123';
+    process.env.GITHUB_TOKEN = 'ghp_test';
+    const store = createSubscriberStore();
+    expect(store).toBeInstanceOf(GistStore);
+  });
+
+  it('throws when GITHUB_GIST_ID is missing for gist', () => {
+    process.env.SUBSCRIBER_STORE = 'gist';
+    delete process.env.GITHUB_GIST_ID;
+    process.env.GITHUB_TOKEN = 'ghp_test';
+    expect(() => createSubscriberStore()).toThrow('Missing GITHUB_GIST_ID');
+  });
+
+  it('throws when GITHUB_TOKEN is missing for gist', () => {
+    process.env.SUBSCRIBER_STORE = 'gist';
+    process.env.GITHUB_GIST_ID = 'abc123';
+    delete process.env.GITHUB_TOKEN;
+    expect(() => createSubscriberStore()).toThrow('Missing GITHUB_TOKEN');
+  });
+});
+
+describe('GistStore', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGistUpdate.mockResolvedValue({});
+  });
+
+  function mockGistFiles(files: Record<string, string>) {
+    mockGistGet.mockResolvedValue({
+      data: {
+        files: Object.fromEntries(
+          Object.entries(files).map(([name, content]) => [name, { content }]),
+        ),
+      },
+    });
+  }
+
+  it('getSubscribers returns matching subscribers from gist', async () => {
+    mockGistFiles({
+      'subscribers.json': JSON.stringify([
+        { email: 'alice@test.com', name: 'Alice', productIds: ['my-app'] },
+        { email: 'bob@test.com', productIds: ['other'] },
+      ]),
+    });
+
+    const store = new GistStore('gist123', 'token');
+    const subs = await store.getSubscribers('my-app');
+
+    expect(subs).toEqual([{ email: 'alice@test.com', name: 'Alice' }]);
+    expect(mockGistGet).toHaveBeenCalledWith({ gist_id: 'gist123' });
+  });
+
+  it('getSubscribers returns empty array when gist file missing', async () => {
+    mockGistGet.mockResolvedValue({ data: { files: {} } });
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const store = new GistStore('gist123', 'token');
+    const subs = await store.getSubscribers('my-app');
+
+    expect(subs).toEqual([]);
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it('addSubscriber creates new entry in gist', async () => {
+    mockGistFiles({ 'subscribers.json': '[]' });
+
+    const store = new GistStore('gist123', 'token');
+    await store.addSubscriber('my-app', 'alice@test.com', 'Alice');
+
+    expect(mockGistUpdate).toHaveBeenCalledWith({
+      gist_id: 'gist123',
+      files: {
+        'subscribers.json': {
+          content: expect.stringContaining('"alice@test.com"'),
+        },
+      },
+    });
+  });
+
+  it('addSubscriber appends productId to existing subscriber', async () => {
+    mockGistFiles({
+      'subscribers.json': JSON.stringify([
+        { email: 'alice@test.com', name: 'Alice', productIds: ['app-a'] },
+      ]),
+    });
+
+    const store = new GistStore('gist123', 'token');
+    await store.addSubscriber('app-b', 'alice@test.com');
+
+    const written = JSON.parse(mockGistUpdate.mock.calls[0][0].files['subscribers.json'].content);
+    expect(written[0].productIds).toEqual(['app-a', 'app-b']);
+  });
+
+  it('addSubscriber creates file when gist has no subscribers.json', async () => {
+    mockGistGet.mockResolvedValue({ data: { files: {} } });
+
+    const store = new GistStore('gist123', 'token');
+    await store.addSubscriber('my-app', 'alice@test.com');
+
+    const written = JSON.parse(mockGistUpdate.mock.calls[0][0].files['subscribers.json'].content);
+    expect(written).toHaveLength(1);
+    expect(written[0].email).toBe('alice@test.com');
+  });
+
+  it('removeSubscriber removes productId from subscriber', async () => {
+    mockGistFiles({
+      'subscribers.json': JSON.stringify([
+        { email: 'alice@test.com', productIds: ['app-a', 'app-b'] },
+      ]),
+    });
+
+    const store = new GistStore('gist123', 'token');
+    await store.removeSubscriber('app-a', 'alice@test.com');
+
+    const written = JSON.parse(mockGistUpdate.mock.calls[0][0].files['subscribers.json'].content);
+    expect(written[0].productIds).toEqual(['app-b']);
+  });
+
+  it('removeSubscriber removes entry when no productIds left', async () => {
+    mockGistFiles({
+      'subscribers.json': JSON.stringify([
+        { email: 'alice@test.com', productIds: ['my-app'] },
+      ]),
+    });
+
+    const store = new GistStore('gist123', 'token');
+    await store.removeSubscriber('my-app', 'alice@test.com');
+
+    const written = JSON.parse(mockGistUpdate.mock.calls[0][0].files['subscribers.json'].content);
+    expect(written).toEqual([]);
+  });
+
+  it('removeSubscriber is no-op when gist file missing', async () => {
+    mockGistGet.mockResolvedValue({ data: { files: {} } });
+
+    const store = new GistStore('gist123', 'token');
+    await store.removeSubscriber('my-app', 'alice@test.com');
+
+    expect(mockGistUpdate).not.toHaveBeenCalled();
+  });
+
+  it('recordEmailSent appends to email log in gist', async () => {
+    mockGistFiles({ 'email-log.json': '[]' });
+
+    const store = new GistStore('gist123', 'token');
+    await store.recordEmailSent('alice@test.com', 'my-app', '2024-01-15');
+
+    const written = JSON.parse(mockGistUpdate.mock.calls[0][0].files['email-log.json'].content);
+    expect(written).toHaveLength(1);
+    expect(written[0].email).toBe('alice@test.com');
+    expect(written[0].productId).toBe('my-app');
+  });
+
+  it('recordEmailSent creates log file when missing', async () => {
+    mockGistGet.mockResolvedValue({ data: { files: {} } });
+
+    const store = new GistStore('gist123', 'token');
+    await store.recordEmailSent('alice@test.com', 'my-app', '2024-01-15');
+
+    expect(mockGistUpdate).toHaveBeenCalled();
+    const written = JSON.parse(mockGistUpdate.mock.calls[0][0].files['email-log.json'].content);
+    expect(written).toHaveLength(1);
   });
 });

--- a/src/subscriber-store.ts
+++ b/src/subscriber-store.ts
@@ -1,5 +1,6 @@
 import { readFileSync, writeFileSync, existsSync } from 'fs';
 import { createClient } from '@supabase/supabase-js';
+import { Octokit } from 'octokit';
 
 export interface Subscriber {
   email: string;
@@ -249,9 +250,99 @@ export class GoogleSheetsStore implements SubscriberStore {
   }
 }
 
+// --- GistStore ---
+
+interface GistFileContent {
+  content: string;
+}
+
+export class GistStore implements SubscriberStore {
+  private octokit: Octokit;
+  private gistId: string;
+  private subscribersFile = 'subscribers.json';
+  private emailLogFile = 'email-log.json';
+
+  constructor(gistId: string, token: string) {
+    this.gistId = gistId;
+    this.octokit = new Octokit({ auth: token });
+  }
+
+  private async readGistFile(filename: string): Promise<string | null> {
+    const { data } = await this.octokit.rest.gists.get({ gist_id: this.gistId });
+    const file = data.files?.[filename] as GistFileContent | undefined;
+    return file?.content ?? null;
+  }
+
+  private async writeGistFile(filename: string, content: string): Promise<void> {
+    await this.octokit.rest.gists.update({
+      gist_id: this.gistId,
+      files: { [filename]: { content } },
+    });
+  }
+
+  async getSubscribers(productId: string): Promise<Subscriber[]> {
+    const raw = await this.readGistFile(this.subscribersFile);
+    if (!raw) {
+      console.warn(`[subscribers] Gist file not found: ${this.subscribersFile}`);
+      return [];
+    }
+
+    const entries: JsonSubscriberEntry[] = JSON.parse(raw);
+    const subscribers = entries
+      .filter((e) => e.productIds.includes(productId))
+      .map((e) => ({ email: e.email, name: e.name }));
+
+    if (subscribers.length === 0) {
+      console.warn(`[subscribers] No active subscribers found for product: ${productId}`);
+    }
+
+    return subscribers;
+  }
+
+  async recordEmailSent(email: string, productId: string, weekOf: string): Promise<void> {
+    const raw = await this.readGistFile(this.emailLogFile);
+    const log: JsonEmailLogEntry[] = raw ? JSON.parse(raw) : [];
+    log.push({ email, productId, weekOf, sentAt: new Date().toISOString() });
+    await this.writeGistFile(this.emailLogFile, JSON.stringify(log, null, 2) + '\n');
+  }
+
+  async addSubscriber(productId: string, email: string, name?: string): Promise<void> {
+    const raw = await this.readGistFile(this.subscribersFile);
+    const entries: JsonSubscriberEntry[] = raw ? JSON.parse(raw) : [];
+
+    const existing = entries.find((e) => e.email === email);
+    if (existing) {
+      if (!existing.productIds.includes(productId)) {
+        existing.productIds.push(productId);
+      }
+      if (name) existing.name = name;
+    } else {
+      entries.push({ email, name, productIds: [productId] });
+    }
+
+    await this.writeGistFile(this.subscribersFile, JSON.stringify(entries, null, 2) + '\n');
+  }
+
+  async removeSubscriber(productId: string, email: string): Promise<void> {
+    const raw = await this.readGistFile(this.subscribersFile);
+    if (!raw) return;
+
+    let entries: JsonSubscriberEntry[] = JSON.parse(raw);
+    const existing = entries.find((e) => e.email === email);
+    if (!existing) return;
+
+    existing.productIds = existing.productIds.filter((id) => id !== productId);
+    if (existing.productIds.length === 0) {
+      entries = entries.filter((e) => e.email !== email);
+    }
+
+    await this.writeGistFile(this.subscribersFile, JSON.stringify(entries, null, 2) + '\n');
+  }
+}
+
 // --- Factory ---
 
-export type SubscriberStoreType = 'supabase' | 'json' | 'google-sheets';
+export type SubscriberStoreType = 'supabase' | 'json' | 'google-sheets' | 'gist';
 
 export function createSubscriberStore(overrides?: {
   store?: SubscriberStoreType;
@@ -280,7 +371,14 @@ export function createSubscriberStore(overrides?: {
       if (!privateKey) throw new Error('Missing GOOGLE_PRIVATE_KEY environment variable');
       return new GoogleSheetsStore(spreadsheetId, email, privateKey);
     }
+    case 'gist': {
+      const gistId = process.env.GITHUB_GIST_ID;
+      const token = process.env.GITHUB_TOKEN;
+      if (!gistId) throw new Error('Missing GITHUB_GIST_ID environment variable');
+      if (!token) throw new Error('Missing GITHUB_TOKEN environment variable');
+      return new GistStore(gistId, token);
+    }
     default:
-      throw new Error(`Unknown subscriber store: ${storeType}. Supported: supabase, json, google-sheets`);
+      throw new Error(`Unknown subscriber store: ${storeType}. Supported: supabase, json, google-sheets, gist`);
   }
 }


### PR DESCRIPTION
## Summary

- Adds `GistStore` subscriber store adapter backed by a private GitHub Gist — solves the problem of exposing subscriber emails in public repos that use the JSON file store
- Same JSON format as `JsonFileStore`, full `SubscriberStore` interface (CRUD + email logging)
- Uses Octokit gist API (already a dependency), configured via `SUBSCRIBER_STORE=gist` + `GITHUB_GIST_ID`
- Updated composite action (`send-file`) with `github-gist-id` and `github-token` inputs
- Added docs page, updated environment reference, comparison table, and JSON store page with public repo caution

## Test plan

- [x] 13 new unit tests for `GistStore` (factory wiring, all CRUD ops, edge cases)
- [x] All 419 tests pass
- [x] Typecheck clean
- [ ] Manual: create a private gist, set `SUBSCRIBER_STORE=gist`, verify add/get/remove subscribers

🤖 Generated with [Claude Code](https://claude.com/claude-code)