### PR TITLE
fix: skip draft-email when drafts already exist

### DIFF
--- a/.github/workflows/draft-email.yml
+++ b/.github/workflows/draft-email.yml
@@ -46,7 +46,19 @@ jobs:
           AUDIENCES=$(grep -A1 '^\s*- id:' products/cryyer.yaml | grep 'id:' | awk '{print $3}' | tr '\n' ' ')
           echo "list=$AUDIENCES" >> "$GITHUB_OUTPUT"
 
+      - name: Check if drafts already exist
+        id: check
+        run: |
+          MISSING=false
+          for AUDIENCE in ${{ steps.audiences.outputs.list }}; do
+            if [ ! -f "drafts/v${{ steps.version.outputs.value }}-${AUDIENCE}.md" ]; then
+              MISSING=true
+            fi
+          done
+          echo "needs_draft=$MISSING" >> "$GITHUB_OUTPUT"
+
       - name: Generate drafts per audience
+        if: steps.check.outputs.needs_draft == 'true'
         run: |
           for AUDIENCE in ${{ steps.audiences.outputs.list }}; do
             echo "::group::Drafting for audience: $AUDIENCE"
@@ -65,6 +77,7 @@ jobs:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
 
       - name: Commit drafts
+        if: steps.check.outputs.needs_draft == 'true'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
## Summary

- Draft-email was re-running on every `synchronize` event, pushing a new commit each time even when drafts already existed
- Pushes from `GITHUB_TOKEN` don't retrigger `pull_request` workflows, so CI was permanently stuck behind the draft-email commit
- This is why PR #115 has CI stuck pending — draft-email keeps pushing on top of CI's commit
- Fix: check if draft files exist before generating, skip the generate + commit steps if they do

## Test plan

- [ ] Merge this, then the release-please PR should pick up the fix on next sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)