### PR TITLE
fix: only run draft-email on PR opened

### DIFF
--- a/.github/workflows/draft-email.yml
+++ b/.github/workflows/draft-email.yml
@@ -2,7 +2,7 @@ name: Draft Email
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened]
 
 jobs:
   draft:


### PR DESCRIPTION
## Summary

- Changes `draft-email.yml` trigger from `[opened, synchronize]` to `[opened]`
- Root cause of CI being stuck on PR #115: draft-email runs on every push, pushes a new commit via `GITHUB_TOKEN`, which doesn't retrigger CI — so CI is permanently behind
- With `opened` only, drafts generate once when release-please creates the PR, and all subsequent pushes only trigger CI

## Test plan

- [ ] Merge this → release-please rebases → CI runs without draft-email pushing on top

🤖 Generated with [Claude Code](https://claude.com/claude-code)