### PR TITLE
fix: use PAT for draft-email push so CI retriggers

### DIFF
--- a/.github/workflows/draft-email.yml
+++ b/.github/workflows/draft-email.yml
@@ -2,20 +2,18 @@ name: Draft Email
 
 on:
   pull_request:
-    types: [opened]
+    types: [opened, synchronize]
 
 jobs:
   draft:
     if: startsWith(github.head_ref, 'release-please--')
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: read
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
 
       - name: Extract version and compute since
         id: version


### PR DESCRIPTION
## Summary

- Uses `RELEASE_PLEASE_TOKEN` instead of `GITHUB_TOKEN` for checkout/push in draft-email
- Pushes from `GITHUB_TOKEN` don't trigger `pull_request` events (GitHub infinite loop prevention) — this is why CI was stuck
- Restores `[opened, synchronize]` trigger so drafts regenerate after release-please rebases
- Keeps skip-if-exists check to avoid redundant generation

This is the proper fix. The previous two PRs (#116, #117) were band-aids.

## Test plan

- [ ] Merge → release-please rebases → draft-email generates drafts → push retriggers CI → all checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)