### PR TITLE
fix: gist store requires PAT, not default GITHUB_TOKEN

### DIFF
--- a/.github/actions/send-file/action.yml
+++ b/.github/actions/send-file/action.yml
@@ -48,9 +48,8 @@ inputs:
     description: Gist ID for subscriber storage (required when subscriber-store is gist)
     required: false
   github-token:
-    description: GitHub token for gist access (required when subscriber-store is gist)
+    description: GitHub PAT with gist scope (required when subscriber-store is gist)
     required: false
-    default: ${{ github.token }}
   audience:
     description: Audience ID for multi-audience products
     required: false

--- a/site/src/content/docs/configuration/environment.mdx
+++ b/site/src/content/docs/configuration/environment.mdx
@@ -63,7 +63,7 @@ See [LLM Providers](/llm-providers) for setup details.
 | Variable | Description |
 |---|---|
 | `GITHUB_GIST_ID` | ID of a private Gist containing `subscribers.json` |
-| `GITHUB_TOKEN` | GitHub token with gist scope (automatic in Actions) |
+| `GITHUB_TOKEN` | GitHub PAT with `gist` scope (the default Actions token cannot access private gists) |
 
 ### Google Sheets
 

--- a/site/src/content/docs/getting-started.mdx
+++ b/site/src/content/docs/getting-started.mdx
@@ -84,6 +84,18 @@ Both pipelines gather GitHub activity (merged PRs, releases, notable commits), g
 
 See [GitHub Actions](/github-actions) for setup details.
 
+## Public repos
+
+If your repo is **public**, don't use the default JSON subscriber store — `subscribers.json` would need to be committed, exposing subscriber emails. Use the [GitHub Gist store](/subscriber-stores/gist) instead. It keeps the same JSON format in a private Gist:
+
+```bash
+SUBSCRIBER_STORE=gist
+GITHUB_GIST_ID=your_gist_id
+GITHUB_TOKEN=ghp_your_pat   # PAT with gist scope
+```
+
+See [GitHub Gist Store](/subscriber-stores/gist) for setup steps.
+
 ## Next steps
 
 - [Configure your products](/configuration/product-config)

--- a/site/src/content/docs/github-actions/composite-actions.mdx
+++ b/site/src/content/docs/github-actions/composite-actions.mdx
@@ -64,7 +64,7 @@ Reads a YAML front matter draft file, loads product config, fetches subscribers,
 | `google-service-account-email` | no | — | Google service account email |
 | `google-private-key` | no | — | Google service account private key |
 | `github-gist-id` | no | — | Gist ID for subscriber storage |
-| `github-token` | no | `github.token` | GitHub token for gist access |
+| `github-token` | no | — | GitHub PAT with `gist` scope (required for gist store) |
 | `audience` | no | — | Audience ID for multi-audience products |
 | `dry-run` | no | `false` | Preview without sending |
 | `cryyer-version` | no | `latest` | Cryyer npm package version |

--- a/site/src/content/docs/subscriber-stores/gist.mdx
+++ b/site/src/content/docs/subscriber-stores/gist.mdx
@@ -21,28 +21,31 @@ Create a [new secret Gist](https://gist.github.com/) with a file named `subscrib
 
 Copy the Gist ID from the URL (e.g., `https://gist.github.com/yourname/abc123def456` → `abc123def456`).
 
-### 2. Add the Gist ID as a repository secret
+### 2. Create a GitHub PAT with `gist` scope
+
+The default `GITHUB_TOKEN` in Actions is scoped to the repository and **cannot access private gists**. Create a [fine-grained PAT](https://github.com/settings/tokens?type=beta) or classic PAT with the `gist` scope.
+
+### 3. Add repository secrets
 
 ```bash
 gh secret set SUBSCRIBERS_GIST_ID --body "abc123def456"
+gh secret set SUBSCRIBERS_GIST_TOKEN --body "ghp_your_pat_here"
 ```
 
-### 3. Set environment variables
+### 4. Set environment variables (local dev)
 
 ```bash
 export SUBSCRIBER_STORE=gist
 export GITHUB_GIST_ID=abc123def456
-export GITHUB_TOKEN=ghp_...
+export GITHUB_TOKEN=ghp_your_pat_here
 ```
-
-In GitHub Actions, `GITHUB_TOKEN` is already available automatically.
 
 ## Configuration
 
 | Variable | Required | Description |
 |---|---|---|
 | `GITHUB_GIST_ID` | Yes | ID of the private Gist |
-| `GITHUB_TOKEN` | Yes | GitHub token with `gist` scope (automatic in Actions) |
+| `GITHUB_TOKEN` | Yes | GitHub PAT with `gist` scope (the default `GITHUB_TOKEN` in Actions cannot access private gists) |
 
 ## File format
 
@@ -88,9 +91,12 @@ Sent emails are logged to an `email-log.json` file in the same Gist (created aut
     email-api-key: ${{ secrets.RESEND_API_KEY }}
     subscriber-store: gist
     github-gist-id: ${{ secrets.SUBSCRIBERS_GIST_ID }}
+    github-token: ${{ secrets.SUBSCRIBERS_GIST_TOKEN }}
 ```
 
-The `github-token` input defaults to `${{ github.token }}`, which already has gist access in Actions.
+:::caution
+You must use a PAT with `gist` scope — the default `${{ github.token }}` cannot access private gists.
+:::
 
 ## Managing subscribers
 


### PR DESCRIPTION
## Summary

- The default `GITHUB_TOKEN` in Actions cannot access private gists — it's scoped to the repo
- Updated gist docs to explain PAT requirement with `gist` scope
- Removed incorrect `${{ github.token }}` default from composite action
- Updated environment and composite action docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)