### PR TITLE
fix: retry LLM call once on unparseable response

### DIFF
--- a/src/summarize.ts
+++ b/src/summarize.ts
@@ -59,7 +59,13 @@ Respond with ONLY a JSON object — no explanation, no markdown fences, just the
 }`;
 
   const text = await provider.generate(prompt, 2048);
-  return parseResponse(text);
+  try {
+    return parseResponse(text);
+  } catch {
+    console.warn('[summarize] LLM returned unparseable response, retrying once...');
+    const retry = await provider.generate(prompt, 2048);
+    return parseResponse(retry);
+  }
 }
 
 export function formatActivity(activity: GatheredActivity): string {


### PR DESCRIPTION
## Summary

- Gemini occasionally truncates JSON output mid-response, crashing the draft generation
- This happened on PR #120's draft-email run
- Fix: retry the LLM call once before failing

🤖 Generated with [Claude Code](https://claude.com/claude-code)