### PR TITLE
docs: gist store requires classic PAT, not fine-grained

### DIFF
--- a/.github/actions/send-file/action.yml
+++ b/.github/actions/send-file/action.yml
@@ -48,7 +48,7 @@ inputs:
     description: Gist ID for subscriber storage (required when subscriber-store is gist)
     required: false
   github-token:
-    description: GitHub PAT with gist scope (required when subscriber-store is gist)
+    description: Classic PAT with gist scope (fine-grained PATs don't work; required when subscriber-store is gist)
     required: false
   audience:
     description: Audience ID for multi-audience products

--- a/README.md
+++ b/README.md
@@ -128,13 +128,13 @@ SUBSCRIBER_STORE=gist
 | Variable | Description |
 |---|---|
 | `GITHUB_GIST_ID` | ID of a private Gist containing `subscribers.json` |
-| `GITHUB_TOKEN` | PAT with gist access: classic PAT with `gist` scope, or fine-grained PAT with Gists read/write (the default Actions token cannot access private gists) |
+| `GITHUB_TOKEN` | Classic PAT with `gist` scope (fine-grained PATs do not support gists; the default Actions token cannot access private gists) |
 
 **Setup:**
 
 1. Create a [secret Gist](https://gist.github.com/) with a file named `subscribers.json` containing `[]`
 2. Copy the Gist ID from the URL
-3. Create a PAT with gist access — [classic PAT](https://github.com/settings/tokens/new) with `gist` scope, or [fine-grained PAT](https://github.com/settings/tokens?type=beta) with Gists read/write
+3. Create a [classic PAT](https://github.com/settings/tokens/new) with `gist` scope (fine-grained PATs don't work with gists)
 4. Add both as repo secrets (`SUBSCRIBERS_GIST_ID`, `SUBSCRIBERS_GIST_TOKEN`)
 
 Same file format as the JSON store:

--- a/site/src/content/docs/configuration/environment.mdx
+++ b/site/src/content/docs/configuration/environment.mdx
@@ -63,7 +63,7 @@ See [LLM Providers](/llm-providers) for setup details.
 | Variable | Description |
 |---|---|
 | `GITHUB_GIST_ID` | ID of a private Gist containing `subscribers.json` |
-| `GITHUB_TOKEN` | PAT with gist access: classic PAT with `gist` scope, or fine-grained PAT with Gists read/write (the default Actions token cannot access private gists) |
+| `GITHUB_TOKEN` | Classic PAT with `gist` scope (fine-grained PATs do not support gists; the default Actions token cannot access private gists) |
 
 ### Google Sheets
 

--- a/site/src/content/docs/getting-started.mdx
+++ b/site/src/content/docs/getting-started.mdx
@@ -91,7 +91,7 @@ If your repo is **public**, don't use the default JSON subscriber store — `sub
 ```bash
 SUBSCRIBER_STORE=gist
 GITHUB_GIST_ID=your_gist_id
-GITHUB_TOKEN=ghp_your_pat   # PAT with gist access (classic: gist scope; fine-grained: Gists read/write)
+GITHUB_TOKEN=ghp_your_pat   # classic PAT with gist scope (fine-grained PATs don't work)
 ```
 
 See [GitHub Gist Store](/subscriber-stores/gist) for setup steps.

--- a/site/src/content/docs/subscriber-stores/gist.mdx
+++ b/site/src/content/docs/subscriber-stores/gist.mdx
@@ -21,12 +21,13 @@ Create a [new secret Gist](https://gist.github.com/) with a file named `subscrib
 
 Copy the Gist ID from the URL (e.g., `https://gist.github.com/yourname/abc123def456` → `abc123def456`).
 
-### 2. Create a GitHub PAT with gist access
+### 2. Create a classic PAT with `gist` scope
 
-The default `GITHUB_TOKEN` in Actions is scoped to the repository and **cannot access private gists**. Create one of:
+The default `GITHUB_TOKEN` in Actions is scoped to the repository and **cannot access private gists**. Create a [classic PAT](https://github.com/settings/tokens/new) and check the **gist** scope.
 
-- **[Classic PAT](https://github.com/settings/tokens/new)** — check the `gist` scope
-- **[Fine-grained PAT](https://github.com/settings/tokens?type=beta)** — enable **Gists** → Read and write under Account permissions
+:::note
+You must use a **classic** PAT (starts with `ghp_`). Fine-grained PATs do not support gist API access.
+:::
 
 ### 3. Add repository secrets
 
@@ -48,7 +49,7 @@ export GITHUB_TOKEN=ghp_your_pat_here
 | Variable | Required | Description |
 |---|---|---|
 | `GITHUB_GIST_ID` | Yes | ID of the private Gist |
-| `GITHUB_TOKEN` | Yes | PAT with gist access — classic PAT with `gist` scope, or fine-grained PAT with Gists read/write (the default Actions token cannot access private gists) |
+| `GITHUB_TOKEN` | Yes | Classic PAT with `gist` scope (fine-grained PATs do not support gists; the default Actions token cannot access private gists) |
 
 ## File format
 
@@ -98,7 +99,7 @@ Sent emails are logged to an `email-log.json` file in the same Gist (created aut
 ```
 
 :::caution
-You must use a PAT with gist access — the default `${{ github.token }}` cannot access private gists. Use a classic PAT with `gist` scope, or a fine-grained PAT with **Gists** read/write permission.
+You must use a **classic** PAT with `gist` scope — fine-grained PATs do not support gists, and the default `${{ github.token }}` cannot access private gists.
 :::
 
 ## Managing subscribers


### PR DESCRIPTION
## Summary
- Fine-grained PATs do not actually support gist API access (despite listing a "Gists" permission in the UI)
- Correct all docs to specify **classic PAT** (`ghp_` prefix) with `gist` scope
- Reverts the incorrect fine-grained guidance added in #124
- Also updates the `send-file` composite action description

**Files changed:** README.md, gist.mdx, environment.mdx, getting-started.mdx, send-file/action.yml

## Context
noxaudit works (uses a dedicated `SUBSCRIBER_GIST_TOKEN` classic PAT), while tokencost-dev was broken (reused `RELEASE_PLEASE_TOKEN` which is fine-grained).

## Test plan
- [ ] Verify docs site renders correctly
- [ ] Confirm the admonition note in gist.mdx renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)