### PR TITLE
feat: add Social types and extend Product with social config

### DIFF
--- a/src/social/types.ts
+++ b/src/social/types.ts
@@ -1,0 +1,36 @@
+export type ContentType = 'pain' | 'insight' | 'capability' | 'proof' | 'update';
+
+export interface Seed {
+  type: ContentType;
+  text: string;
+}
+
+export interface Platform {
+  id: string;
+  name: string;
+  maxLength: number;
+  voice: string;
+  threadSupport?: boolean;
+  threadMaxParts?: number;
+}
+
+export interface SocialPost {
+  platform: string;
+  seed: Seed;
+  content: string;
+}
+
+export interface SocialDraft {
+  product: string;
+  generatedAt: string;
+  posts: SocialPost[];
+}
+
+export interface SocialConfig {
+  platforms: string[];
+  context: string;
+  cta?: {
+    default: string;
+    link: string;
+  };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import type { SocialConfig } from './social/types.js';
+
 export interface ProductFilter {
   labels?: string[];
   paths?: string[];
@@ -37,6 +39,7 @@ export interface Product {
   from_email?: string;
   reply_to?: string;
   audiences?: Audience[];
+  social?: SocialConfig;
 }
 
 export interface BetaTester {


### PR DESCRIPTION
## Summary
- Adds `src/social/types.ts` with `ContentType`, `Seed`, `Platform`, `SocialPost`, `SocialDraft`, and `SocialConfig` types
- Extends `Product` in `src/types.ts` with optional `social?: SocialConfig` field

Closes #128