### PR TITLE
feat: seed parser and platform config loader (Phase 1)

### DIFF
--- a/platforms/bluesky.yaml
+++ b/platforms/bluesky.yaml
@@ -1,0 +1,4 @@
+id: bluesky
+name: Bluesky
+maxLength: 300
+voice: "conversational, dev-oriented, no hashtags (Bluesky culture)"

--- a/platforms/linkedin.yaml
+++ b/platforms/linkedin.yaml
@@ -1,0 +1,4 @@
+id: linkedin
+name: LinkedIn
+maxLength: 3000
+voice: "professional but not corporate, first-person, lead with a hook (first 2 lines visible before 'see more'), 2-3 hashtags at end max"

--- a/platforms/twitter.yaml
+++ b/platforms/twitter.yaml
@@ -1,0 +1,6 @@
+id: twitter
+name: Twitter
+maxLength: 280
+voice: "concise, direct, technical audience, 1-2 hashtags max, no emoji unless meaningful"
+threadSupport: true
+threadMaxParts: 4

--- a/src/__tests__/parse-seeds.test.ts
+++ b/src/__tests__/parse-seeds.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { writeFileSync, mkdirSync, rmSync } from 'fs';
+import { join } from 'path';
+import { parseSeeds } from '../social/parse-seeds.js';
+
+const TMP_DIR = join(process.cwd(), '.tmp-test-seeds');
+
+function seedFile(name: string, content: string): string {
+  mkdirSync(TMP_DIR, { recursive: true });
+  const path = join(TMP_DIR, name);
+  writeFileSync(path, content, 'utf-8');
+  return path;
+}
+
+afterEach(() => {
+  rmSync(TMP_DIR, { recursive: true, force: true });
+});
+
+describe('parseSeeds', () => {
+  it('parses a valid seed file with one seed per type', () => {
+    const path = seedFile('valid.md', [
+      '## pain',
+      'most devs run linters but never catch architectural drift',
+      '',
+      '## insight',
+      'we rotate between claude, gpt-4, and gemini because each catches different things',
+    ].join('\n'));
+
+    const seeds = parseSeeds(path);
+    expect(seeds).toHaveLength(2);
+    expect(seeds[0]).toEqual({
+      type: 'pain',
+      text: 'most devs run linters but never catch architectural drift',
+    });
+    expect(seeds[1]).toEqual({
+      type: 'insight',
+      text: 'we rotate between claude, gpt-4, and gemini because each catches different things',
+    });
+  });
+
+  it('parses multiple seeds per type (separated by blank lines)', () => {
+    const path = seedFile('multi.md', [
+      '## pain',
+      'first pain point',
+      '',
+      'second pain point',
+      '',
+      '## capability',
+      'a capability seed',
+    ].join('\n'));
+
+    const seeds = parseSeeds(path);
+    expect(seeds).toHaveLength(3);
+    expect(seeds[0]).toEqual({ type: 'pain', text: 'first pain point' });
+    expect(seeds[1]).toEqual({ type: 'pain', text: 'second pain point' });
+    expect(seeds[2]).toEqual({ type: 'capability', text: 'a capability seed' });
+  });
+
+  it('throws on unknown content type', () => {
+    const path = seedFile('unknown.md', [
+      '## rant',
+      'this should fail',
+    ].join('\n'));
+
+    expect(() => parseSeeds(path)).toThrow('Unknown content type: "rant"');
+  });
+
+  it('returns empty array for an empty file', () => {
+    const path = seedFile('empty.md', '');
+    const seeds = parseSeeds(path);
+    expect(seeds).toEqual([]);
+  });
+
+  it('returns empty array for file with no headings', () => {
+    const path = seedFile('noheadings.md', 'just some text without headings');
+    const seeds = parseSeeds(path);
+    expect(seeds).toEqual([]);
+  });
+
+  it('handles all valid content types', () => {
+    const types = ['pain', 'insight', 'capability', 'proof', 'update', 'blog'];
+    const lines = types.flatMap((t) => [`## ${t}`, `${t} seed text`, '']);
+    const path = seedFile('alltypes.md', lines.join('\n'));
+
+    const seeds = parseSeeds(path);
+    expect(seeds).toHaveLength(6);
+    for (let i = 0; i < types.length; i++) {
+      expect(seeds[i].type).toBe(types[i]);
+      expect(seeds[i].text).toBe(`${types[i]} seed text`);
+    }
+  });
+
+  it('handles multi-line paragraphs within a seed', () => {
+    const path = seedFile('multiline.md', [
+      '## insight',
+      'line one of the insight',
+      'line two of the insight',
+      '',
+      'separate seed',
+    ].join('\n'));
+
+    const seeds = parseSeeds(path);
+    expect(seeds).toHaveLength(2);
+    expect(seeds[0].text).toBe('line one of the insight\nline two of the insight');
+    expect(seeds[1].text).toBe('separate seed');
+  });
+});

--- a/src/__tests__/platforms.test.ts
+++ b/src/__tests__/platforms.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { writeFileSync, mkdirSync, rmSync } from 'fs';
+import { join } from 'path';
+import { loadPlatforms } from '../social/platforms.js';
+
+const TMP_DIR = join(process.cwd(), '.tmp-test-platforms');
+
+function platformFile(name: string, content: string): void {
+  mkdirSync(TMP_DIR, { recursive: true });
+  writeFileSync(join(TMP_DIR, name), content, 'utf-8');
+}
+
+afterEach(() => {
+  rmSync(TMP_DIR, { recursive: true, force: true });
+});
+
+describe('loadPlatforms', () => {
+  it('loads all platform YAML files from the default platforms/ directory', () => {
+    const platforms = loadPlatforms(join(process.cwd(), 'platforms'));
+    expect(platforms.length).toBe(3);
+    const ids = platforms.map((p) => p.id).sort();
+    expect(ids).toEqual(['bluesky', 'linkedin', 'twitter']);
+  });
+
+  it('validates required fields on each platform', () => {
+    const platforms = loadPlatforms(join(process.cwd(), 'platforms'));
+    for (const platform of platforms) {
+      expect(typeof platform.id).toBe('string');
+      expect(platform.id.length).toBeGreaterThan(0);
+      expect(typeof platform.name).toBe('string');
+      expect(platform.name.length).toBeGreaterThan(0);
+      expect(typeof platform.maxLength).toBe('number');
+      expect(platform.maxLength).toBeGreaterThan(0);
+      expect(typeof platform.voice).toBe('string');
+      expect(platform.voice.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('loads optional thread fields on twitter', () => {
+    const platforms = loadPlatforms(join(process.cwd(), 'platforms'));
+    const twitter = platforms.find((p) => p.id === 'twitter');
+    expect(twitter).toBeDefined();
+    expect(twitter!.threadSupport).toBe(true);
+    expect(twitter!.threadMaxParts).toBe(4);
+  });
+
+  it('omits thread fields on platforms without them', () => {
+    const platforms = loadPlatforms(join(process.cwd(), 'platforms'));
+    const linkedin = platforms.find((p) => p.id === 'linkedin');
+    expect(linkedin).toBeDefined();
+    expect(linkedin!.threadSupport).toBeUndefined();
+    expect(linkedin!.threadMaxParts).toBeUndefined();
+  });
+
+  it('throws when id is missing', () => {
+    platformFile('bad.yaml', 'name: Bad\nmaxLength: 100\nvoice: "test"');
+    expect(() => loadPlatforms(TMP_DIR)).toThrow('missing required field "id"');
+  });
+
+  it('throws when name is missing', () => {
+    platformFile('bad.yaml', 'id: bad\nmaxLength: 100\nvoice: "test"');
+    expect(() => loadPlatforms(TMP_DIR)).toThrow('missing required field "name"');
+  });
+
+  it('throws when maxLength is missing', () => {
+    platformFile('bad.yaml', 'id: bad\nname: Bad\nvoice: "test"');
+    expect(() => loadPlatforms(TMP_DIR)).toThrow('missing or invalid required field "maxLength"');
+  });
+
+  it('throws when voice is missing', () => {
+    platformFile('bad.yaml', 'id: bad\nname: Bad\nmaxLength: 100');
+    expect(() => loadPlatforms(TMP_DIR)).toThrow('missing required field "voice"');
+  });
+
+  it('loads from a custom directory', () => {
+    platformFile('custom.yaml', [
+      'id: mastodon',
+      'name: Mastodon',
+      'maxLength: 500',
+      'voice: "friendly, open-source vibes"',
+    ].join('\n'));
+
+    const platforms = loadPlatforms(TMP_DIR);
+    expect(platforms).toHaveLength(1);
+    expect(platforms[0].id).toBe('mastodon');
+  });
+
+  it('throws on non-existent directory', () => {
+    expect(() => loadPlatforms('/tmp/nonexistent-cryyer-platforms')).toThrow();
+  });
+});

--- a/src/social/parse-seeds.ts
+++ b/src/social/parse-seeds.ts
@@ -1,0 +1,72 @@
+import { readFileSync } from 'fs';
+import type { ContentType, Seed } from './types.js';
+
+const VALID_TYPES: ReadonlySet<string> = new Set<ContentType>([
+  'pain',
+  'insight',
+  'capability',
+  'proof',
+  'update',
+  'blog',
+]);
+
+/**
+ * Parse a markdown seed file into an array of Seed objects.
+ *
+ * Expected format:
+ * ```
+ * ## pain
+ * first seed paragraph
+ *
+ * second seed paragraph
+ *
+ * ## insight
+ * another seed
+ * ```
+ *
+ * One seed per paragraph under each `## type` heading.
+ */
+export function parseSeeds(filePath: string): Seed[] {
+  const content = readFileSync(filePath, 'utf-8');
+  const lines = content.split('\n');
+
+  const seeds: Seed[] = [];
+  let currentType: ContentType | null = null;
+  let currentParagraph: string[] = [];
+
+  const flushParagraph = (): void => {
+    if (currentType && currentParagraph.length > 0) {
+      const text = currentParagraph.join('\n').trim();
+      if (text) {
+        seeds.push({ type: currentType, text });
+      }
+    }
+    currentParagraph = [];
+  };
+
+  for (const line of lines) {
+    const headingMatch = line.match(/^##\s+(.+)$/);
+    if (headingMatch) {
+      flushParagraph();
+      const type = headingMatch[1].trim().toLowerCase();
+      if (!VALID_TYPES.has(type)) {
+        throw new Error(`Unknown content type: "${type}"`);
+      }
+      currentType = type as ContentType;
+      continue;
+    }
+
+    if (currentType === null) {
+      continue;
+    }
+
+    if (line.trim() === '') {
+      flushParagraph();
+    } else {
+      currentParagraph.push(line);
+    }
+  }
+
+  flushParagraph();
+  return seeds;
+}

--- a/src/social/platforms.ts
+++ b/src/social/platforms.ts
@@ -1,0 +1,37 @@
+import { readFileSync, readdirSync } from 'fs';
+import { join } from 'path';
+import { parse as parseYaml } from 'yaml';
+import type { Platform } from './types.js';
+
+/**
+ * Load platform configurations from YAML files in the given directory.
+ * Defaults to `platforms/` relative to the project root (process.cwd()).
+ */
+export function loadPlatforms(dir?: string): Platform[] {
+  const platformsDir = dir ?? join(process.cwd(), 'platforms');
+  const files = readdirSync(platformsDir).filter(
+    (f) => f.endsWith('.yaml') || f.endsWith('.yml'),
+  );
+
+  return files.map((file) => {
+    const content = readFileSync(join(platformsDir, file), 'utf-8');
+    const platform = parseYaml(content) as Platform;
+    validatePlatform(platform, file);
+    return platform;
+  });
+}
+
+function validatePlatform(platform: Platform, file: string): void {
+  if (!platform.id) {
+    throw new Error(`Platform in ${file}: missing required field "id"`);
+  }
+  if (!platform.name) {
+    throw new Error(`Platform "${platform.id}" in ${file}: missing required field "name"`);
+  }
+  if (platform.maxLength == null || typeof platform.maxLength !== 'number') {
+    throw new Error(`Platform "${platform.id}" in ${file}: missing or invalid required field "maxLength"`);
+  }
+  if (!platform.voice) {
+    throw new Error(`Platform "${platform.id}" in ${file}: missing required field "voice"`);
+  }
+}

--- a/src/social/types.ts
+++ b/src/social/types.ts
@@ -1,4 +1,4 @@
-export type ContentType = 'pain' | 'insight' | 'capability' | 'proof' | 'update';
+export type ContentType = 'pain' | 'insight' | 'capability' | 'proof' | 'update' | 'blog';
 
 export interface Seed {
   type: ContentType;
@@ -15,14 +15,15 @@ export interface Platform {
 }
 
 export interface SocialPost {
-  platform: string;
   seed: Seed;
-  content: string;
+  platform: Platform;
+  text: string;
 }
 
 export interface SocialDraft {
   product: string;
   generatedAt: string;
+  seeds: number;
   posts: SocialPost[];
 }
 


### PR DESCRIPTION
## Summary

- Updates `src/social/types.ts` to add `'blog'` content type and align `SocialPost`/`SocialDraft` interfaces with the social pipeline spec
- Adds `src/social/parse-seeds.ts` with `parseSeeds()` -- parses markdown seed files (`## type` headings, one seed per paragraph) into typed `Seed[]`
- Adds `src/social/platforms.ts` with `loadPlatforms()` -- loads and validates platform YAML configs from a directory
- Ships 3 default platform configs: `platforms/twitter.yaml`, `platforms/linkedin.yaml`, `platforms/bluesky.yaml`
- 17 new tests covering both modules (valid parsing, multi-seed per type, unknown type errors, empty files, field validation, custom dirs)

Closes #129, closes #130

## Test plan

- [x] `pnpm run typecheck` passes
- [x] `pnpm run lint` passes (no new warnings)
- [x] `pnpm test` -- all 436 tests pass (22 files), including 17 new tests
- [ ] CI confirms green on push

:robot: Generated with [Claude Code](https://claude.com/claude-code)