### PR TITLE
feat: social CLI commands (seed, draft, send) with Buffer provider

### DIFF
--- a/src/__tests__/social-buffer-provider.test.ts
+++ b/src/__tests__/social-buffer-provider.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { listProfiles, createPost } from '../social/buffer-provider.js';
+
+const mockFetch = vi.fn();
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', mockFetch);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('listProfiles', () => {
+  it('returns profiles from the API', async () => {
+    const profiles = [
+      { id: 'p1', service: 'twitter', formatted_service: 'Twitter' },
+      { id: 'p2', service: 'linkedin', formatted_service: 'LinkedIn' },
+    ];
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(profiles),
+    });
+
+    const result = await listProfiles('test-token');
+    expect(result).toEqual(profiles);
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('profiles.json?access_token=test-token'),
+    );
+  });
+
+  it('throws on non-OK response', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      statusText: 'Unauthorized',
+    });
+
+    await expect(listProfiles('bad-token')).rejects.toThrow(
+      'Buffer API error: 401 Unauthorized',
+    );
+  });
+});
+
+describe('createPost', () => {
+  it('sends a post and returns the update ID', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          success: true,
+          updates: [{ id: 'u123' }],
+        }),
+    });
+
+    const id = await createPost('token', 'profile1', 'Hello world');
+    expect(id).toBe('u123');
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('updates/create.json'),
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+
+  it('includes scheduled_at when provided', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          success: true,
+          updates: [{ id: 'u456' }],
+        }),
+    });
+
+    await createPost('token', 'profile1', 'Scheduled', '2026-04-01T10:00:00Z');
+    const lastCall = mockFetch.mock.calls[mockFetch.mock.calls.length - 1];
+    const body = lastCall[1].body as string;
+    expect(body).toContain('scheduled_at');
+  });
+
+  it('throws when success is false', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ success: false }),
+    });
+
+    await expect(
+      createPost('token', 'profile1', 'fail'),
+    ).rejects.toThrow('post creation failed');
+  });
+});

--- a/src/__tests__/social-draft.test.ts
+++ b/src/__tests__/social-draft.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { parseArgv } from '../social/draft.js';
+
+describe('social draft parseArgv', () => {
+  it('parses --product flag', () => {
+    const result = parseArgv(['--product', 'noxaudit']);
+    expect(result.productId).toBe('noxaudit');
+    expect(result.dryRun).toBe(false);
+    expect(result.type).toBeUndefined();
+  });
+
+  it('parses --type flag', () => {
+    const result = parseArgv(['--product', 'noxaudit', '--type', 'pain']);
+    expect(result.type).toBe('pain');
+  });
+
+  it('parses --dry-run flag', () => {
+    const result = parseArgv(['--product', 'noxaudit', '--dry-run']);
+    expect(result.dryRun).toBe(true);
+  });
+
+  it('parses --config-dir flag', () => {
+    const result = parseArgv([
+      '--product',
+      'noxaudit',
+      '--config-dir',
+      '/custom/dir',
+    ]);
+    expect(result.configDir).toBe('/custom/dir');
+  });
+
+  it('strips leading "draft" command word', () => {
+    const result = parseArgv(['draft', '--product', 'noxaudit']);
+    expect(result.productId).toBe('noxaudit');
+  });
+
+  it('throws when --product is missing', () => {
+    expect(() => parseArgv(['--type', 'pain'])).toThrow('Missing --product');
+  });
+});

--- a/src/__tests__/social-seed.test.ts
+++ b/src/__tests__/social-seed.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { readFileSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { parseArgv, appendSeed } from '../social/seed.js';
+
+const TMP_DIR = join(process.cwd(), '.tmp-test-social-seed');
+
+afterEach(() => {
+  rmSync(TMP_DIR, { recursive: true, force: true });
+});
+
+describe('parseArgv', () => {
+  it('parses productId, type, and text from positional args', () => {
+    const result = parseArgv(['noxaudit', 'pain', 'devs ignore drift']);
+    expect(result).toEqual({
+      productId: 'noxaudit',
+      type: 'pain',
+      text: 'devs ignore drift',
+    });
+  });
+
+  it('joins multi-word text arguments', () => {
+    const result = parseArgv(['noxaudit', 'insight', 'multi', 'word', 'text']);
+    expect(result.text).toBe('multi word text');
+  });
+
+  it('strips leading "seed" command word', () => {
+    const result = parseArgv(['seed', 'noxaudit', 'pain', 'some text']);
+    expect(result.productId).toBe('noxaudit');
+    expect(result.type).toBe('pain');
+  });
+
+  it('throws on too few arguments', () => {
+    expect(() => parseArgv(['noxaudit', 'pain'])).toThrow('Usage:');
+  });
+
+  it('throws on unknown content type', () => {
+    expect(() => parseArgv(['noxaudit', 'rant', 'text'])).toThrow(
+      'Unknown content type: "rant"',
+    );
+  });
+});
+
+describe('appendSeed', () => {
+  it('creates a new file when none exists', () => {
+    const filePath = appendSeed(TMP_DIR, 'testprod', 'pain', 'first seed');
+    expect(filePath).toBe(join(TMP_DIR, 'testprod.md'));
+    const content = readFileSync(filePath, 'utf-8');
+    expect(content).toBe('## pain\nfirst seed\n');
+  });
+
+  it('appends under existing heading', () => {
+    const seedsDir = TMP_DIR;
+    mkdirSync(seedsDir, { recursive: true });
+    writeFileSync(join(seedsDir, 'testprod.md'), '## pain\nfirst seed\n', 'utf-8');
+
+    appendSeed(seedsDir, 'testprod', 'pain', 'second seed');
+    const content = readFileSync(join(seedsDir, 'testprod.md'), 'utf-8');
+    expect(content).toContain('## pain');
+    expect(content).toContain('first seed');
+    expect(content).toContain('second seed');
+    // Both seeds should be under the same heading
+    const headingCount = (content.match(/## pain/g) ?? []).length;
+    expect(headingCount).toBe(1);
+  });
+
+  it('adds a new heading when type does not exist', () => {
+    const seedsDir = TMP_DIR;
+    mkdirSync(seedsDir, { recursive: true });
+    writeFileSync(join(seedsDir, 'testprod.md'), '## pain\nexisting\n', 'utf-8');
+
+    appendSeed(seedsDir, 'testprod', 'insight', 'new insight');
+    const content = readFileSync(join(seedsDir, 'testprod.md'), 'utf-8');
+    expect(content).toContain('## pain');
+    expect(content).toContain('## insight');
+    expect(content).toContain('new insight');
+  });
+
+  it('appends between existing headings correctly', () => {
+    const seedsDir = TMP_DIR;
+    mkdirSync(seedsDir, { recursive: true });
+    writeFileSync(
+      join(seedsDir, 'testprod.md'),
+      '## pain\npain seed\n\n## insight\ninsight seed\n',
+      'utf-8',
+    );
+
+    appendSeed(seedsDir, 'testprod', 'pain', 'another pain');
+    const content = readFileSync(join(seedsDir, 'testprod.md'), 'utf-8');
+
+    // "another pain" should appear before "## insight"
+    const painPos = content.indexOf('another pain');
+    const insightHeadingPos = content.indexOf('## insight');
+    expect(painPos).toBeLessThan(insightHeadingPos);
+  });
+});

--- a/src/__tests__/social-send.test.ts
+++ b/src/__tests__/social-send.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { parseArgv } from '../social/send.js';
+
+describe('social send parseArgv', () => {
+  it('parses a positional draft path', () => {
+    const result = parseArgv(['social-drafts/noxaudit-2026-03-24.md']);
+    expect(result.draftPath).toBe('social-drafts/noxaudit-2026-03-24.md');
+    expect(result.dryRun).toBe(false);
+  });
+
+  it('parses --dry-run flag', () => {
+    const result = parseArgv(['draft.md', '--dry-run']);
+    expect(result.draftPath).toBe('draft.md');
+    expect(result.dryRun).toBe(true);
+  });
+
+  it('strips leading "send" command word', () => {
+    const result = parseArgv(['send', 'draft.md']);
+    expect(result.draftPath).toBe('draft.md');
+  });
+
+  it('throws when no draft path provided', () => {
+    expect(() => parseArgv(['--dry-run'])).toThrow('Missing draft path');
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -27,6 +27,7 @@ Commands:
   draft-file    Generate a draft → write to markdown file
   send-file     Send emails from a draft markdown file
   preview       Show gathered activity without drafting
+  social        Social content pipeline (seed, draft, send)
 
 Options:
   --help, -h    Show this help message
@@ -34,6 +35,51 @@ Options:
 
 Run 'cryyer <command> --help' for more information on a command.
 `.trimStart());
+}
+
+function printSocialHelp(): void {
+  console.log(`
+cryyer social — social content pipeline
+
+Usage:
+  cryyer social <command> [options]
+
+Commands:
+  seed <productId> <type> "<text>"        Add a seed to seeds/{productId}.md
+  draft --product <id> [--type <type>]    Generate social posts from seeds
+  send <draft-path>                       Send posts to Buffer queue
+
+Options:
+  --help, -h    Show this help message
+
+Run 'cryyer social <command> --help' for more information on a command.
+`.trimStart());
+}
+
+async function runSocial(args: string[]): Promise<void> {
+  const subcommand = args[0];
+
+  if (!subcommand || subcommand === '--help' || subcommand === '-h') {
+    printSocialHelp();
+    return;
+  }
+
+  const socialCommands: Record<string, string> = {
+    seed: './social/seed.js',
+    draft: './social/draft.js',
+    send: './social/send.js',
+  };
+
+  const modulePath = socialCommands[subcommand];
+  if (!modulePath) {
+    console.error(`Unknown social command: ${subcommand}\n`);
+    printSocialHelp();
+    process.exitCode = 1;
+    return;
+  }
+
+  const mod = await import(modulePath) as { main: () => Promise<void> };
+  await mod.main();
 }
 
 async function run(): Promise<void> {
@@ -47,6 +93,11 @@ async function run(): Promise<void> {
 
   if (command === '--version' || command === '-V') {
     console.log(getVersion());
+    return;
+  }
+
+  if (command === 'social') {
+    await runSocial(args.slice(1));
     return;
   }
 

--- a/src/social/buffer-provider.ts
+++ b/src/social/buffer-provider.ts
@@ -1,0 +1,66 @@
+export interface BufferProfile {
+  id: string;
+  service: string;
+  formatted_service: string;
+}
+
+export interface BufferCreateResponse {
+  success: boolean;
+  updates: Array<{ id: string }>;
+}
+
+const BUFFER_API_BASE = 'https://api.bufferapp.com/1';
+
+/**
+ * List all profiles for the authenticated Buffer account.
+ */
+export async function listProfiles(token: string): Promise<BufferProfile[]> {
+  const url = `${BUFFER_API_BASE}/profiles.json?access_token=${encodeURIComponent(token)}`;
+
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Buffer API error: ${response.status} ${response.statusText}`);
+  }
+
+  return (await response.json()) as BufferProfile[];
+}
+
+/**
+ * Create a post in a Buffer profile's queue.
+ * Returns the created update ID.
+ */
+export async function createPost(
+  token: string,
+  profileId: string,
+  text: string,
+  scheduledAt?: string,
+): Promise<string> {
+  const url = `${BUFFER_API_BASE}/updates/create.json`;
+
+  const body: Record<string, string> = {
+    access_token: token,
+    text,
+    'profile_ids[]': profileId,
+  };
+
+  if (scheduledAt) {
+    body['scheduled_at'] = scheduledAt;
+  }
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams(body).toString(),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Buffer API error: ${response.status} ${response.statusText}`);
+  }
+
+  const result = (await response.json()) as BufferCreateResponse;
+  if (!result.success || !result.updates?.length) {
+    throw new Error('Buffer API: post creation failed');
+  }
+
+  return result.updates[0].id;
+}

--- a/src/social/draft.ts
+++ b/src/social/draft.ts
@@ -1,0 +1,140 @@
+import { join } from 'path';
+import { fileURLToPath } from 'url';
+import { Octokit } from 'octokit';
+import { loadProducts } from '../config.js';
+import { gatherActivity } from '../gather.js';
+import { createLLMProvider } from '../llm-provider.js';
+import { parseSeeds } from './parse-seeds.js';
+import { loadPlatforms } from './platforms.js';
+import { generateSocialPosts } from './generate.js';
+import { writeSocialDraft } from './draft-file.js';
+import type { ContentType, SocialDraft } from './types.js';
+
+export function parseArgv(argv: string[]): {
+  productId: string;
+  type?: ContentType;
+  dryRun: boolean;
+  configDir?: string;
+} {
+  const args = argv[0] === 'draft' ? argv.slice(1) : argv;
+
+  let productId: string | undefined;
+  let type: ContentType | undefined;
+  let dryRun = false;
+  let configDir: string | undefined = process.env['CRYYER_CONFIG_DIR'];
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--product' && args[i + 1]) {
+      productId = args[i + 1];
+      i++;
+    } else if (args[i] === '--type' && args[i + 1]) {
+      type = args[i + 1] as ContentType;
+      i++;
+    } else if (args[i] === '--dry-run') {
+      dryRun = true;
+    } else if (args[i] === '--config-dir' && args[i + 1]) {
+      configDir = args[i + 1];
+      i++;
+    }
+  }
+
+  if (!productId) {
+    throw new Error(
+      'Missing --product <id>. Usage: cryyer social draft --product <id> [--type <type>] [--dry-run]',
+    );
+  }
+
+  return { productId, type, dryRun, configDir: configDir || undefined };
+}
+
+export async function main(): Promise<void> {
+  const { productId, type, dryRun, configDir } = parseArgv(process.argv.slice(2));
+
+  const root = configDir ?? process.cwd();
+  const productsDir = join(root, 'products');
+  const products = loadProducts(productsDir);
+  const product = products.find((p) => p.id === productId);
+  if (!product) {
+    throw new Error(
+      `Product not found: ${productId}. Available: ${products.map((p) => p.id).join(', ')}`,
+    );
+  }
+
+  if (!product.social?.platforms?.length) {
+    throw new Error(
+      `Product "${productId}" has no social.platforms configured`,
+    );
+  }
+
+  // Load all platforms, then filter to ones listed in product config
+  const allPlatforms = loadPlatforms(join(root, 'platforms'));
+  const platforms = allPlatforms.filter((p) =>
+    product.social!.platforms.includes(p.id),
+  );
+  if (platforms.length === 0) {
+    throw new Error(
+      `No matching platform configs found for: ${product.social.platforms.join(', ')}`,
+    );
+  }
+
+  // Parse seeds
+  const seedsFile = join(root, 'seeds', `${productId}.md`);
+  let seeds = parseSeeds(seedsFile);
+
+  // Filter by type if provided
+  if (type) {
+    seeds = seeds.filter((s) => s.type === type);
+    if (seeds.length === 0) {
+      throw new Error(`No seeds found with type "${type}" in ${seedsFile}`);
+    }
+  }
+
+  // Gather activity for update-type seeds
+  let activity;
+  const hasUpdateSeeds = seeds.some((s) => s.type === 'update');
+  if (hasUpdateSeeds && product.repo) {
+    const githubToken = process.env['GITHUB_TOKEN'];
+    if (!githubToken) {
+      throw new Error(
+        'GITHUB_TOKEN required for update-type seeds (needs to gather repo activity)',
+      );
+    }
+    const octokit = new Octokit({ auth: githubToken });
+    const since = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
+    console.log(`Gathering activity for ${product.name} since ${since}`);
+    activity = await gatherActivity(octokit, product, since);
+  }
+
+  // Generate posts
+  const llm = createLLMProvider();
+  console.log(`Generating posts for ${seeds.length} seeds across ${platforms.length} platforms...`);
+  const posts = await generateSocialPosts(llm, product, seeds, platforms, activity);
+
+  if (dryRun) {
+    for (const post of posts) {
+      console.log(`\n--- ${post.seed.type} | ${post.platform.id} ---`);
+      console.log(post.text);
+    }
+    console.log('\nDry run complete');
+    return;
+  }
+
+  // Write draft file
+  const draft: SocialDraft = {
+    product: productId,
+    generatedAt: new Date().toISOString(),
+    seeds: seeds.length,
+    posts,
+  };
+
+  const outputDir = join(root, 'social-drafts');
+  const filePath = writeSocialDraft(draft, outputDir);
+  console.log(filePath);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((err) => {
+    console.error('Fatal error:', err);
+    process.exit(1);
+  });
+}

--- a/src/social/seed.ts
+++ b/src/social/seed.ts
@@ -1,0 +1,103 @@
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs';
+import { join } from 'path';
+import { fileURLToPath } from 'url';
+import type { ContentType } from './types.js';
+
+const VALID_TYPES: ReadonlySet<string> = new Set<ContentType>([
+  'pain',
+  'insight',
+  'capability',
+  'proof',
+  'update',
+  'blog',
+]);
+
+export function parseArgv(argv: string[]): {
+  productId: string;
+  type: ContentType;
+  text: string;
+} {
+  // argv may come from cli.ts with 'seed' stripped, or from process.argv.slice(2) with 'social seed' stripped
+  const args = argv[0] === 'seed' ? argv.slice(1) : argv;
+
+  if (args.length < 3) {
+    throw new Error('Usage: cryyer social seed <productId> <type> "<text>"');
+  }
+
+  const productId = args[0];
+  const type = args[1];
+  const text = args.slice(2).join(' ');
+
+  if (!VALID_TYPES.has(type)) {
+    throw new Error(
+      `Unknown content type: "${type}". Valid types: ${[...VALID_TYPES].join(', ')}`,
+    );
+  }
+
+  return { productId, type: type as ContentType, text };
+}
+
+/**
+ * Append a seed to the markdown seed file for a product.
+ * Creates the file and parent directories if they don't exist.
+ * Appends under the matching `## type` heading, or creates it.
+ */
+export function appendSeed(
+  seedsDir: string,
+  productId: string,
+  type: ContentType,
+  text: string,
+): string {
+  mkdirSync(seedsDir, { recursive: true });
+  const filePath = join(seedsDir, `${productId}.md`);
+
+  if (!existsSync(filePath)) {
+    const content = `## ${type}\n${text}\n`;
+    writeFileSync(filePath, content, 'utf-8');
+    return filePath;
+  }
+
+  const existing = readFileSync(filePath, 'utf-8');
+  const headingPattern = new RegExp(`^## ${type}$`, 'm');
+  const match = headingPattern.exec(existing);
+
+  if (match) {
+    // Find the end of this section (next heading or EOF)
+    const afterHeading = existing.slice(match.index + match[0].length);
+    const nextHeading = afterHeading.search(/^## /m);
+    const insertPos =
+      nextHeading === -1
+        ? existing.length
+        : match.index + match[0].length + nextHeading;
+
+    // Ensure there's a blank line before the new paragraph
+    const before = existing.slice(0, insertPos).replace(/\n*$/, '');
+    const after = existing.slice(insertPos);
+
+    const content = `${before}\n\n${text}\n${after}`;
+    writeFileSync(filePath, content, 'utf-8');
+  } else {
+    // Add new heading section at the end
+    const normalized = existing.replace(/\n*$/, '');
+    const content = `${normalized}\n\n## ${type}\n${text}\n`;
+    writeFileSync(filePath, content, 'utf-8');
+  }
+
+  return filePath;
+}
+
+export async function main(): Promise<void> {
+  const { productId, type, text } = parseArgv(process.argv.slice(2));
+
+  const seedsDir = join(process.cwd(), 'seeds');
+  const filePath = appendSeed(seedsDir, productId, type, text);
+
+  console.log(`Added ${type} seed to ${filePath}`);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((err) => {
+    console.error('Fatal error:', err);
+    process.exit(1);
+  });
+}

--- a/src/social/send.ts
+++ b/src/social/send.ts
@@ -1,0 +1,102 @@
+import { fileURLToPath } from 'url';
+import { readSocialDraft } from './draft-file.js';
+import * as bufferProvider from './buffer-provider.js';
+
+const PLATFORM_ENV_MAP: Record<string, string> = {
+  twitter: 'BUFFER_PROFILE_TWITTER',
+  linkedin: 'BUFFER_PROFILE_LINKEDIN',
+  bluesky: 'BUFFER_PROFILE_BLUESKY',
+};
+
+export function parseArgv(argv: string[]): {
+  draftPath: string;
+  dryRun: boolean;
+} {
+  const args = argv[0] === 'send' ? argv.slice(1) : argv;
+
+  let draftPath: string | undefined;
+  let dryRun = false;
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--dry-run') {
+      dryRun = true;
+    } else if (!args[i].startsWith('-') && !draftPath) {
+      draftPath = args[i];
+    }
+  }
+
+  if (!draftPath) {
+    throw new Error(
+      'Missing draft path. Usage: cryyer social send <draft-path> [--dry-run]',
+    );
+  }
+
+  return { draftPath, dryRun };
+}
+
+export async function main(): Promise<void> {
+  const { draftPath, dryRun } = parseArgv(process.argv.slice(2));
+
+  const draft = readSocialDraft(draftPath);
+
+  const token = process.env['BUFFER_ACCESS_TOKEN'];
+  if (!token && !dryRun) {
+    throw new Error('Missing BUFFER_ACCESS_TOKEN environment variable');
+  }
+
+  // Build platform-to-profile mapping
+  const profileMap = new Map<string, string>();
+  if (!dryRun) {
+    const profiles = await bufferProvider.listProfiles(token!);
+    for (const [platformId, envVar] of Object.entries(PLATFORM_ENV_MAP)) {
+      const envProfileId = process.env[envVar];
+      if (envProfileId) {
+        // Verify profile exists
+        const found = profiles.find((p) => p.id === envProfileId);
+        if (!found) {
+          console.warn(
+            `Warning: ${envVar}=${envProfileId} not found in Buffer profiles`,
+          );
+        }
+        profileMap.set(platformId, envProfileId);
+      }
+    }
+  }
+
+  let queued = 0;
+  const platformCounts = new Map<string, number>();
+
+  for (const post of draft.posts) {
+    const platformId = post.platform.id;
+
+    if (dryRun) {
+      console.log(`\n[DRY RUN] ${platformId}:`);
+      console.log(post.text);
+      queued++;
+      platformCounts.set(platformId, (platformCounts.get(platformId) ?? 0) + 1);
+      continue;
+    }
+
+    const profileId = profileMap.get(platformId);
+    if (!profileId) {
+      console.warn(
+        `Skipping ${platformId}: no profile configured (set ${PLATFORM_ENV_MAP[platformId] ?? `BUFFER_PROFILE_${platformId.toUpperCase()}`})`,
+      );
+      continue;
+    }
+
+    await bufferProvider.createPost(token!, profileId, post.text);
+    queued++;
+    platformCounts.set(platformId, (platformCounts.get(platformId) ?? 0) + 1);
+  }
+
+  const platformCount = platformCounts.size;
+  console.log(`\nQueued ${queued} posts across ${platformCount} platforms`);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((err) => {
+    console.error('Fatal error:', err);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary
- Implements `cryyer social seed <productId> <type> "<text>"` to append seeds to markdown files (#135)
- Implements `cryyer social draft --product <id> [--type <type>] [--dry-run]` to generate social posts from seeds via LLM (#134)
- Implements `cryyer social send <draft-path> [--dry-run]` to publish draft posts to Buffer queue (#136)
- Adds Buffer API provider with `listProfiles` and `createPost` functions
- Wires all three as `social` subcommands in `cli.ts`

## Test plan
- [x] All 487 existing + new tests pass
- [x] TypeScript typecheck passes
- [x] ESLint passes (no new warnings)
- [ ] Manual: `cryyer social seed noxaudit pain "some text"` creates/appends to `seeds/noxaudit.md`
- [ ] Manual: `cryyer social draft --product <id> --dry-run` with LLM key generates posts to stdout
- [ ] Manual: `cryyer social send <path> --dry-run` reads draft and prints what would be posted

Closes #134, closes #135, closes #136

Generated with [Claude Code](https://claude.com/claude-code)