### PR TITLE
feat: external config directory + example social configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,13 @@ products/*.yaml
 # Release email drafts (generated, not public)
 drafts/
 
+# Social seeds (keep only example.md; user seeds stay local)
+seeds/*.md
+!seeds/example.md
+
+# Social drafts (generated output)
+social-drafts/
+
 # Subscriber data (local JSON store)
 # subscribers.json is committed for cryyer's own dogfooding
 email-log.json

--- a/products/example.yaml
+++ b/products/example.yaml
@@ -22,3 +22,15 @@ emailSubjectTemplate: "{{weekOf}} Weekly Update — Example Product"  # or "Exam
 #     voice: "Professional and concise, focused on stability and compliance"
 #     emailSubjectTemplate: "{{weekOf}} Release Notes — Example Product"  # or "Example Product v{{version}}"
 #     from_name: "Example Product Team"
+
+# Optional: social content pipeline configuration
+social:
+  platforms: [twitter, linkedin, bluesky]
+  context: |
+    Cryyer is an automated email update tool for software teams. It connects to your GitHub
+    repo, uses LLMs to draft release notes and weekly updates in your product's voice,
+    and sends them to your subscriber list. Designed for indie developers and small teams
+    who want to keep users informed without manual effort.
+  cta:
+    default: "Try Cryyer"
+    link: "https://github.com/atriumn/cryyer"

--- a/seeds/example.md
+++ b/seeds/example.md
@@ -1,0 +1,14 @@
+## pain
+most teams skip release notes entirely because writing them takes longer than shipping the feature
+
+## insight
+automating release notes isn't about laziness — it's about consistency; users trust products that communicate regularly
+
+## capability
+you can now send personalized release notes to different audience segments from the same GitHub activity
+
+## proof
+teams using automated release notes see 40% higher open rates compared to manual monthly newsletters
+
+## blog
+why most developer tools fail at user communication — and how to fix it without a marketing team

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -50,7 +50,11 @@ Commands:
   send <draft-path>                       Send posts to Buffer queue
 
 Options:
-  --help, -h    Show this help message
+  --config-dir <path>  Config directory (products/, seeds/, social-drafts/)
+  --help, -h           Show this help message
+
+Environment:
+  CRYYER_CONFIG_DIR    Fallback for --config-dir when flag is not provided
 
 Run 'cryyer social <command> --help' for more information on a command.
 `.trimStart());

--- a/src/social/seed.ts
+++ b/src/social/seed.ts
@@ -16,17 +16,32 @@ export function parseArgv(argv: string[]): {
   productId: string;
   type: ContentType;
   text: string;
+  configDir?: string;
 } {
   // argv may come from cli.ts with 'seed' stripped, or from process.argv.slice(2) with 'social seed' stripped
   const args = argv[0] === 'seed' ? argv.slice(1) : argv;
 
-  if (args.length < 3) {
-    throw new Error('Usage: cryyer social seed <productId> <type> "<text>"');
+  let configDir: string | undefined = process.env['CRYYER_CONFIG_DIR'];
+  const positional: string[] = [];
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--config-dir' && args[i + 1]) {
+      configDir = args[i + 1];
+      i++;
+    } else {
+      positional.push(args[i]);
+    }
   }
 
-  const productId = args[0];
-  const type = args[1];
-  const text = args.slice(2).join(' ');
+  if (positional.length < 3) {
+    throw new Error(
+      'Usage: cryyer social seed <productId> <type> "<text>" [--config-dir <path>]',
+    );
+  }
+
+  const productId = positional[0];
+  const type = positional[1];
+  const text = positional.slice(2).join(' ');
 
   if (!VALID_TYPES.has(type)) {
     throw new Error(
@@ -34,7 +49,7 @@ export function parseArgv(argv: string[]): {
     );
   }
 
-  return { productId, type: type as ContentType, text };
+  return { productId, type: type as ContentType, text, configDir: configDir || undefined };
 }
 
 /**
@@ -87,9 +102,10 @@ export function appendSeed(
 }
 
 export async function main(): Promise<void> {
-  const { productId, type, text } = parseArgv(process.argv.slice(2));
+  const { productId, type, text, configDir } = parseArgv(process.argv.slice(2));
 
-  const seedsDir = join(process.cwd(), 'seeds');
+  const root = configDir ?? process.cwd();
+  const seedsDir = join(root, 'seeds');
   const filePath = appendSeed(seedsDir, productId, type, text);
 
   console.log(`Added ${type} seed to ${filePath}`);

--- a/src/social/send.ts
+++ b/src/social/send.ts
@@ -11,15 +11,20 @@ const PLATFORM_ENV_MAP: Record<string, string> = {
 export function parseArgv(argv: string[]): {
   draftPath: string;
   dryRun: boolean;
+  configDir?: string;
 } {
   const args = argv[0] === 'send' ? argv.slice(1) : argv;
 
   let draftPath: string | undefined;
   let dryRun = false;
+  let configDir: string | undefined = process.env['CRYYER_CONFIG_DIR'];
 
   for (let i = 0; i < args.length; i++) {
     if (args[i] === '--dry-run') {
       dryRun = true;
+    } else if (args[i] === '--config-dir' && args[i + 1]) {
+      configDir = args[i + 1];
+      i++;
     } else if (!args[i].startsWith('-') && !draftPath) {
       draftPath = args[i];
     }
@@ -27,11 +32,11 @@ export function parseArgv(argv: string[]): {
 
   if (!draftPath) {
     throw new Error(
-      'Missing draft path. Usage: cryyer social send <draft-path> [--dry-run]',
+      'Missing draft path. Usage: cryyer social send <draft-path> [--dry-run] [--config-dir <path>]',
     );
   }
 
-  return { draftPath, dryRun };
+  return { draftPath, dryRun, configDir: configDir || undefined };
 }
 
 export async function main(): Promise<void> {


### PR DESCRIPTION
## Summary

- Add `--config-dir <path>` flag and `CRYYER_CONFIG_DIR` env var to `social seed` and `social send` subcommands (`social draft` already had it from Phase 3), so all three social subcommands consistently support external config directories
- Add `social` block to `products/example.yaml` with platforms, context, and CTA configuration
- Create `seeds/example.md` with one seed per content type (pain, insight, capability, proof, blog)
- Update `.gitignore` to track `seeds/example.md` while ignoring user seed files, and ignore `social-drafts/` output

Closes #143, closes #144

## Test plan

- [x] `pnpm run typecheck` passes
- [x] `pnpm run lint` passes (no new warnings)
- [x] `pnpm test` passes (487/487)
- [ ] Verify `cryyer social seed example-product pain "test" --config-dir /tmp/test` writes to `/tmp/test/seeds/`
- [ ] Verify `CRYYER_CONFIG_DIR=/tmp/test cryyer social seed example-product pain "test"` uses env fallback
- [ ] Verify `products/example.yaml` parses correctly with social block

Generated with [Claude Code](https://claude.com/claude-code)