### PR TITLE
feat: append CTA link to generated social posts

### DIFF
--- a/src/__tests__/social-generate.test.ts
+++ b/src/__tests__/social-generate.test.ts
@@ -54,7 +54,7 @@ describe('generateSocialPosts', () => {
 
     const posts = await generateSocialPosts(provider, product, seeds, [twitter]);
 
-    expect(posts[0].text).toBe('trimmed content');
+    expect(posts[0].text).toBe('trimmed content\nhttps://noxaudit.dev');
   });
 
   it('uses higher maxTokens for blog type', async () => {
@@ -88,7 +88,7 @@ describe('generateSocialPosts', () => {
     );
     // Still returns the post despite warning
     expect(posts).toHaveLength(1);
-    expect(posts[0].text).toBe(longText);
+    expect(posts[0].text).toBe(longText + '\nhttps://noxaudit.dev');
 
     warnSpy.mockRestore();
   });
@@ -139,6 +139,34 @@ describe('generateSocialPosts', () => {
     const provider = mockProvider('content');
     const posts = await generateSocialPosts(provider, product, [], [twitter]);
     expect(posts).toEqual([]);
+  });
+
+  it('appends CTA link when not already in text', async () => {
+    const seeds: Seed[] = [{ type: 'pain', text: 'drift' }];
+    const provider = mockProvider('Check this out');
+
+    const posts = await generateSocialPosts(provider, product, seeds, [twitter]);
+
+    expect(posts[0].text).toBe('Check this out\nhttps://noxaudit.dev');
+  });
+
+  it('does not duplicate CTA link when already in text', async () => {
+    const seeds: Seed[] = [{ type: 'pain', text: 'drift' }];
+    const provider = mockProvider('Check this out https://noxaudit.dev');
+
+    const posts = await generateSocialPosts(provider, product, seeds, [twitter]);
+
+    expect(posts[0].text).toBe('Check this out https://noxaudit.dev');
+  });
+
+  it('skips CTA link when product has no social.cta.link', async () => {
+    const productNoCta: Product = { id: 'bare', name: 'Bare' };
+    const seeds: Seed[] = [{ type: 'pain', text: 'drift' }];
+    const provider = mockProvider('plain post');
+
+    const posts = await generateSocialPosts(provider, productNoCta, seeds, [twitter]);
+
+    expect(posts[0].text).toBe('plain post');
   });
 
   it('returns empty array for no platforms', async () => {

--- a/src/social/generate.ts
+++ b/src/social/generate.ts
@@ -55,7 +55,10 @@ export async function generateSocialPosts(
         );
       }
 
-      posts.push({ seed, platform, text });
+      const ctaLink = product.social?.cta?.link;
+      const finalText = ctaLink && !text.includes(ctaLink) ? `${text}\n${ctaLink}` : text;
+
+      posts.push({ seed, platform, text: finalText });
     }
   }
 


### PR DESCRIPTION
## Summary
- Appends `product.social.cta.link` on a new line after each generated social post, ensuring link preview cards work on LinkedIn/Twitter/Bluesky
- Skips appending if the link is already present in the LLM output or if no CTA link is configured
- Append happens after the char limit warning so the link is always included even if it pushes slightly over

## Test plan
- [x] Existing tests updated to reflect appended CTA link
- [x] New test: appends CTA link when not already in text
- [x] New test: does not duplicate CTA link when already present
- [x] New test: skips CTA link when product has no `social.cta.link`
- [x] All 497 tests pass, typecheck clean, lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)