### PR TITLE
feat: add self-hosted GitHub Actions deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,32 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: self-hosted
+    steps:
+      - name: Pull latest
+        run: |
+          cd /home/jeff/projects/cryyer
+          git fetch origin main
+          git checkout main
+          git reset --hard origin/main
+
+      - name: Install dependencies
+        run: |
+          cd /home/jeff/projects/cryyer
+          pnpm install --frozen-lockfile
+
+      - name: Type check
+        run: |
+          cd /home/jeff/projects/cryyer
+          pnpm run typecheck
+
+      - name: Build
+        run: |
+          cd /home/jeff/projects/cryyer
+          pnpm run build


### PR DESCRIPTION
Adds a deploy workflow that runs on push to main on self-hosted runner.

## Steps
1. Pull latest from origin/main
2. Install dependencies (pnpm install --frozen-lockfile)
3. Type check (pnpm run typecheck)
4. Build (pnpm run build)

No PM2 restart needed since cryyer is a CLI/MCP tool, not a running server.