### PR TITLE
feat: add Claude OAuth token fallback for Anthropic provider

### DIFF
--- a/src/__tests__/check.test.ts
+++ b/src/__tests__/check.test.ts
@@ -8,14 +8,14 @@ vi.mock('@supabase/supabase-js', () => ({
 }));
 vi.mock('fs', async (importOriginal) => {
   const actual = await importOriginal<typeof import('fs')>();
-  return { ...actual, existsSync: vi.fn() };
+  return { ...actual, existsSync: vi.fn(), readFileSync: vi.fn(actual.readFileSync) };
 });
 
 import { checkProducts, checkGitHub, checkLLMProvider, checkSubscriberStore, checkEmailConfig, runChecks, main } from '../check.js';
 import { loadProducts } from '../config.js';
 import { Octokit } from 'octokit';
 import { createClient } from '@supabase/supabase-js';
-import { existsSync } from 'fs';
+import { existsSync, readFileSync } from 'fs';
 
 describe('checkProducts', () => {
   beforeEach(() => {
@@ -137,12 +137,24 @@ describe('checkLLMProvider', () => {
     expect(result.message).toContain('anthropic');
   });
 
-  it('fails when ANTHROPIC_API_KEY is missing', () => {
+  it('fails when ANTHROPIC_API_KEY is missing and no OAuth credentials', () => {
     delete process.env['LLM_PROVIDER'];
     delete process.env['ANTHROPIC_API_KEY'];
+    (readFileSync as Mock).mockImplementation(() => { throw new Error('ENOENT'); });
     const result = checkLLMProvider();
     expect(result.passed).toBe(false);
     expect(result.message).toContain('ANTHROPIC_API_KEY');
+  });
+
+  it('passes when ANTHROPIC_API_KEY is missing but OAuth credentials exist', () => {
+    delete process.env['LLM_PROVIDER'];
+    delete process.env['ANTHROPIC_API_KEY'];
+    (readFileSync as Mock).mockReturnValue(
+      JSON.stringify({ claudeAiOauth: { accessToken: 'oauth-token' } })
+    );
+    const result = checkLLMProvider();
+    expect(result.passed).toBe(true);
+    expect(result.message).toContain('Claude OAuth');
   });
 
   it('passes when OPENAI_API_KEY is set with openai provider', () => {

--- a/src/__tests__/llm-provider.test.ts
+++ b/src/__tests__/llm-provider.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect, afterEach, vi } from 'vitest';
 
+let lastAnthropicOpts: Record<string, unknown> | undefined;
+
 vi.mock('@anthropic-ai/sdk', () => ({
   default: class MockAnthropic {
+    constructor(opts: Record<string, unknown>) {
+      lastAnthropicOpts = opts;
+    }
     messages = {
       create: vi.fn().mockResolvedValue({
         content: [{ type: 'text', text: '{"subject":"S","body":"B"}' }],
@@ -9,6 +14,11 @@ vi.mock('@anthropic-ai/sdk', () => ({
     };
   },
 }));
+
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>();
+  return { ...actual, readFileSync: vi.fn(actual.readFileSync) };
+});
 
 vi.mock('openai', () => ({
   default: class MockOpenAI {
@@ -34,6 +44,8 @@ vi.mock('@google/generative-ai', () => ({
   },
 }));
 
+import { readFileSync } from 'fs';
+import type { Mock } from 'vitest';
 import { createLLMProvider, AnthropicProvider, OpenAIProvider, GeminiProvider } from '../llm-provider.js';
 
 describe('createLLMProvider', () => {
@@ -76,10 +88,30 @@ describe('createLLMProvider', () => {
     expect(() => createLLMProvider()).toThrow('Unknown LLM provider: unknown');
   });
 
-  it('throws when API key is missing for anthropic', () => {
+  it('throws when API key is missing for anthropic and no OAuth credentials', () => {
     delete process.env.ANTHROPIC_API_KEY;
     process.env.LLM_PROVIDER = 'anthropic';
+    // Mock readFileSync to throw (no credentials file)
+    (readFileSync as Mock).mockImplementation((path: string) => {
+      if (typeof path === 'string' && path.includes('.credentials.json')) {
+        throw new Error('ENOENT');
+      }
+      throw new Error('ENOENT');
+    });
     expect(() => createLLMProvider()).toThrow('Missing ANTHROPIC_API_KEY');
+  });
+
+  it('falls back to OAuth when ANTHROPIC_API_KEY is missing but credentials exist', () => {
+    delete process.env.ANTHROPIC_API_KEY;
+    process.env.LLM_PROVIDER = 'anthropic';
+    (readFileSync as Mock).mockImplementation((path: string) => {
+      if (typeof path === 'string' && path.includes('.credentials.json')) {
+        return JSON.stringify({ claudeAiOauth: { accessToken: 'oauth-token-123' } });
+      }
+      throw new Error('ENOENT');
+    });
+    const provider = createLLMProvider();
+    expect(provider).toBeInstanceOf(AnthropicProvider);
   });
 
   it('throws when API key is missing for openai', () => {
@@ -125,6 +157,31 @@ describe('AnthropicProvider.generate', () => {
     const provider = new AnthropicProvider('test-key');
     const result = await provider.generate('test prompt', 1024);
     expect(result).toBe('{"subject":"S","body":"B"}');
+  });
+
+  it('uses OAuth token when useOAuth is true', async () => {
+    (readFileSync as Mock).mockImplementation((path: string) => {
+      if (typeof path === 'string' && path.includes('.credentials.json')) {
+        return JSON.stringify({ claudeAiOauth: { accessToken: 'oauth-test-token' } });
+      }
+      throw new Error('ENOENT');
+    });
+    const provider = new AnthropicProvider(null, undefined, true);
+    const result = await provider.generate('test prompt', 1024);
+    expect(result).toBe('{"subject":"S","body":"B"}');
+    expect(lastAnthropicOpts).toMatchObject({
+      authToken: 'oauth-test-token',
+      apiKey: null,
+      defaultHeaders: { 'anthropic-beta': 'oauth-2025-04-20' },
+    });
+  });
+
+  it('throws when useOAuth is true but no credentials file', async () => {
+    (readFileSync as Mock).mockImplementation(() => {
+      throw new Error('ENOENT');
+    });
+    const provider = new AnthropicProvider(null, undefined, true);
+    await expect(provider.generate('test prompt', 1024)).rejects.toThrow('Claude OAuth token not found');
   });
 });
 

--- a/src/check.ts
+++ b/src/check.ts
@@ -1,6 +1,7 @@
-import { join } from 'path';
+import { join, resolve } from 'path';
 import { fileURLToPath } from 'url';
-import { existsSync } from 'fs';
+import { existsSync, readFileSync } from 'fs';
+import { homedir } from 'os';
 import { Octokit } from 'octokit';
 import { loadProducts } from './config.js';
 
@@ -62,6 +63,17 @@ export async function checkGitHub(): Promise<CheckResult> {
   }
 }
 
+function hasClaudeOAuthCredentials(): boolean {
+  try {
+    const credPath = resolve(homedir(), '.claude', '.credentials.json');
+    const raw = readFileSync(credPath, 'utf-8');
+    const creds = JSON.parse(raw);
+    return !!creds?.claudeAiOauth?.accessToken;
+  } catch {
+    return false;
+  }
+}
+
 export function checkLLMProvider(): CheckResult {
   const provider = process.env['LLM_PROVIDER'] || 'anthropic';
   const keyMap: Record<string, string> = {
@@ -81,6 +93,14 @@ export function checkLLMProvider(): CheckResult {
 
   const apiKey = process.env[envKey];
   if (!apiKey) {
+    // For Anthropic, check Claude OAuth credentials as fallback
+    if (provider === 'anthropic' && hasClaudeOAuthCredentials()) {
+      return {
+        name: 'LLM provider',
+        passed: true,
+        message: `Provider 'anthropic' configured (Claude OAuth credentials found)`,
+      };
+    }
     return {
       name: 'LLM provider',
       passed: false,

--- a/src/llm-provider.ts
+++ b/src/llm-provider.ts
@@ -1,19 +1,55 @@
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { homedir } from 'os';
+
 export interface LLMProvider {
   generate(prompt: string, maxTokens: number): Promise<string>;
 }
 
+function readClaudeOAuthToken(): string | null {
+  try {
+    const credPath = resolve(homedir(), '.claude', '.credentials.json');
+    const raw = readFileSync(credPath, 'utf-8');
+    const creds = JSON.parse(raw);
+    return creds?.claudeAiOauth?.accessToken ?? null;
+  } catch {
+    return null;
+  }
+}
+
 export class AnthropicProvider implements LLMProvider {
-  private apiKey: string;
+  private apiKey: string | null;
+  private useOAuth: boolean;
   private model: string;
 
-  constructor(apiKey: string, model?: string) {
+  constructor(apiKey: string | null, model?: string, useOAuth?: boolean) {
     this.apiKey = apiKey;
+    this.useOAuth = useOAuth ?? false;
     this.model = model || 'claude-sonnet-4-5-20250514';
   }
 
   async generate(prompt: string, maxTokens: number): Promise<string> {
     const { default: Anthropic } = await import('@anthropic-ai/sdk');
-    const client = new Anthropic({ apiKey: this.apiKey });
+
+    let client: InstanceType<typeof Anthropic>;
+    if (this.apiKey) {
+      client = new Anthropic({ apiKey: this.apiKey });
+    } else if (this.useOAuth) {
+      // Re-read token on every call — Claude Code keeps it refreshed
+      const oauthToken = readClaudeOAuthToken();
+      if (!oauthToken) {
+        throw new Error(
+          'Claude OAuth token not found. Ensure Claude Code is running and ~/.claude/.credentials.json exists.'
+        );
+      }
+      client = new Anthropic({
+        authToken: oauthToken,
+        apiKey: null,
+        defaultHeaders: { 'anthropic-beta': 'oauth-2025-04-20' },
+      });
+    } else {
+      throw new Error('No Anthropic API key or OAuth token available');
+    }
 
     const message = await client.messages.create({
       model: this.model,
@@ -94,9 +130,13 @@ export function createLLMProvider(overrides?: {
 
   switch (providerName) {
     case 'anthropic': {
-      const apiKey = overrides?.apiKey || process.env.ANTHROPIC_API_KEY;
-      if (!apiKey) throw new Error('Missing ANTHROPIC_API_KEY environment variable');
-      return new AnthropicProvider(apiKey, model);
+      const apiKey = overrides?.apiKey || process.env.ANTHROPIC_API_KEY || null;
+      if (!apiKey && !readClaudeOAuthToken()) {
+        throw new Error(
+          'Missing ANTHROPIC_API_KEY environment variable and no Claude OAuth credentials found at ~/.claude/.credentials.json'
+        );
+      }
+      return new AnthropicProvider(apiKey, model, !apiKey);
     }
     case 'openai': {
       const apiKey = overrides?.apiKey || process.env.OPENAI_API_KEY;


### PR DESCRIPTION
## Summary

- When `ANTHROPIC_API_KEY` is not set, the Anthropic provider now falls back to reading OAuth credentials from `~/.claude/.credentials.json` (maintained by Claude Code)
- The OAuth token is re-read on every API call since Claude Code refreshes it automatically
- The `checkLLMProvider` health check also recognizes OAuth credentials as a valid configuration

## Changed files

- `src/llm-provider.ts` -- Added `readClaudeOAuthToken()` helper, updated `AnthropicProvider` to support OAuth auth, updated `createLLMProvider` to fall back to OAuth
- `src/check.ts` -- Added `hasClaudeOAuthCredentials()` check so health check passes with OAuth
- `src/__tests__/llm-provider.test.ts` -- Tests for OAuth fallback in provider creation and generate
- `src/__tests__/check.test.ts` -- Tests for OAuth fallback in health check

## Test plan

- [x] `pnpm run typecheck` passes
- [x] `pnpm run lint` passes (only pre-existing warnings)
- [x] All relevant tests pass (18 test files, 409 tests)
- [ ] Manual: verify OAuth works on atriumn-box where Claude Code is running

Generated with [Claude Code](https://claude.com/claude-code)