### PR TITLE
feat: add Claude CLI provider for Opus/Sonnet without API key

### DIFF
--- a/src/__tests__/llm-provider.test.ts
+++ b/src/__tests__/llm-provider.test.ts
@@ -46,7 +46,7 @@ vi.mock('@google/generative-ai', () => ({
 
 import { readFileSync } from 'fs';
 import type { Mock } from 'vitest';
-import { createLLMProvider, AnthropicProvider, OpenAIProvider, GeminiProvider } from '../llm-provider.js';
+import { createLLMProvider, AnthropicProvider, ClaudeCLIProvider, OpenAIProvider, GeminiProvider } from '../llm-provider.js';
 
 describe('createLLMProvider', () => {
   const originalEnv = { ...process.env };
@@ -88,9 +88,10 @@ describe('createLLMProvider', () => {
     expect(() => createLLMProvider()).toThrow('Unknown LLM provider: unknown');
   });
 
-  it('throws when API key is missing for anthropic and no OAuth credentials', () => {
+  it('throws when API key is missing for anthropic haiku and no OAuth credentials', () => {
     delete process.env.ANTHROPIC_API_KEY;
     process.env.LLM_PROVIDER = 'anthropic';
+    process.env.LLM_MODEL = 'claude-haiku-4-5';
     // Mock readFileSync to throw (no credentials file)
     (readFileSync as Mock).mockImplementation((path: string) => {
       if (typeof path === 'string' && path.includes('.credentials.json')) {
@@ -98,12 +99,21 @@ describe('createLLMProvider', () => {
       }
       throw new Error('ENOENT');
     });
-    expect(() => createLLMProvider()).toThrow('Missing ANTHROPIC_API_KEY');
+    expect(() => createLLMProvider()).toThrow('No Claude OAuth credentials found');
   });
 
-  it('falls back to OAuth when ANTHROPIC_API_KEY is missing but credentials exist', () => {
+  it('uses ClaudeCLIProvider for Opus/Sonnet when no API key (regardless of OAuth)', () => {
     delete process.env.ANTHROPIC_API_KEY;
     process.env.LLM_PROVIDER = 'anthropic';
+    delete process.env.LLM_MODEL; // defaults to claude-opus-4-6
+    const provider = createLLMProvider();
+    expect(provider).toBeInstanceOf(ClaudeCLIProvider);
+  });
+
+  it('falls back to OAuth for Haiku when ANTHROPIC_API_KEY is missing but credentials exist', () => {
+    delete process.env.ANTHROPIC_API_KEY;
+    process.env.LLM_PROVIDER = 'anthropic';
+    process.env.LLM_MODEL = 'claude-haiku-4-5';
     (readFileSync as Mock).mockImplementation((path: string) => {
       if (typeof path === 'string' && path.includes('.credentials.json')) {
         return JSON.stringify({ claudeAiOauth: { accessToken: 'oauth-token-123' } });

--- a/src/llm-provider.ts
+++ b/src/llm-provider.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
 import { homedir } from 'os';
+import { spawn } from 'child_process';
 
 export interface LLMProvider {
   generate(prompt: string, maxTokens: number): Promise<string>;
@@ -62,6 +63,52 @@ export class AnthropicProvider implements LLMProvider {
       throw new Error('Unexpected response type from Anthropic API');
     }
     return content.text;
+  }
+}
+
+const CLAUDE_CLI = process.env.CLAUDE_CLI_PATH || 'claude';
+/** Models supported directly via OAuth (Haiku tier) */
+const OAUTH_DIRECT_MODELS = new Set(['claude-haiku-4-5']);
+
+export class ClaudeCLIProvider implements LLMProvider {
+  private model: string;
+
+  constructor(model?: string) {
+    this.model = model || 'claude-opus-4-6';
+  }
+
+  async generate(prompt: string, _maxTokens: number): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const proc = spawn(CLAUDE_CLI, [
+        '-p', '--model', this.model, '--output-format', 'json', '--dangerously-skip-permissions',
+      ], {
+        env: { ...process.env, ANTHROPIC_API_KEY: '' },
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+
+      let stdout = '';
+      let stderr = '';
+      proc.stdout.on('data', (d: Buffer) => { stdout += d; });
+      proc.stderr.on('data', (d: Buffer) => { stderr += d; });
+      proc.stdin.write(prompt);
+      proc.stdin.end();
+
+      const timer = setTimeout(() => { proc.kill(); reject(new Error('claude CLI timeout (5m)')); }, 300_000);
+      proc.on('close', (code: number) => {
+        clearTimeout(timer);
+        if (code !== 0 && !stdout.trim()) {
+          reject(new Error(`claude CLI exited ${code}: ${stderr.slice(0, 300)}`));
+          return;
+        }
+        try {
+          const envelope = JSON.parse(stdout.trim());
+          resolve(envelope.result || stdout);
+        } catch {
+          resolve(stdout);
+        }
+      });
+      proc.on('error', (err: Error) => { clearTimeout(timer); reject(err); });
+    });
   }
 }
 
@@ -131,12 +178,19 @@ export function createLLMProvider(overrides?: {
   switch (providerName) {
     case 'anthropic': {
       const apiKey = overrides?.apiKey || process.env.ANTHROPIC_API_KEY || null;
-      if (!apiKey && !readClaudeOAuthToken()) {
-        throw new Error(
-          'Missing ANTHROPIC_API_KEY environment variable and no Claude OAuth credentials found at ~/.claude/.credentials.json'
-        );
+      const effectiveModel = model || 'claude-opus-4-6';
+      if (apiKey) {
+        return new AnthropicProvider(apiKey, effectiveModel, false);
       }
-      return new AnthropicProvider(apiKey, model, !apiKey);
+      // No API key — use OAuth direct for Haiku, CLI for everything else
+      if (OAUTH_DIRECT_MODELS.has(effectiveModel)) {
+        if (!readClaudeOAuthToken()) {
+          throw new Error('No Claude OAuth credentials found at ~/.claude/.credentials.json');
+        }
+        return new AnthropicProvider(null, effectiveModel, true);
+      }
+      // Opus/Sonnet: spawn the claude CLI (uses Claude Code's own auth)
+      return new ClaudeCLIProvider(effectiveModel);
     }
     case 'openai': {
       const apiKey = overrides?.apiKey || process.env.OPENAI_API_KEY;


### PR DESCRIPTION
## Summary
- Adds `ClaudeCLIProvider` that spawns the `claude` CLI for Opus/Sonnet models — same pattern Arqo uses
- No `ANTHROPIC_API_KEY` needed; uses Claude Code's own OAuth auth automatically
- Haiku stays on direct OAuth API (lightweight, fast)
- Updates default model from `claude-sonnet-4-5-20250514` (404'd) to `claude-opus-4-6`
- Model routing: API key → Haiku stays direct OAuth → Sonnet/Opus spawn CLI

## Test plan
- [ ] `LLM_PROVIDER=anthropic LLM_MODEL=claude-opus-4-6 node dist/cli.js social draft --product authored-systems --type insight` generates posts without ANTHROPIC_API_KEY
- [ ] `LLM_MODEL=claude-haiku-4-5` still uses direct OAuth API

🤖 Generated with [Claude Code](https://claude.com/claude-code)