### PR TITLE
feat: add Bluesky and X direct posting providers

### DIFF
--- a/src/social/bluesky-provider.ts
+++ b/src/social/bluesky-provider.ts
@@ -1,0 +1,76 @@
+export interface BlueskySession {
+  did: string;
+  accessJwt: string;
+}
+
+/**
+ * Authenticate with Bluesky using handle + app password.
+ * Returns a session with DID and access JWT.
+ */
+async function createSession(
+  handle: string,
+  appPassword: string,
+): Promise<BlueskySession> {
+  const response = await fetch(
+    'https://bsky.social/xrpc/com.atproto.server.createSession',
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ identifier: handle, password: appPassword }),
+    },
+  );
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => '');
+    throw new Error(
+      `Bluesky auth error: ${response.status} ${response.statusText}${errorText ? ` — ${errorText}` : ''}`,
+    );
+  }
+
+  const data = (await response.json()) as BlueskySession;
+  return { did: data.did, accessJwt: data.accessJwt };
+}
+
+/**
+ * Post a text update to Bluesky via the AT Protocol.
+ * Returns the AT URI of the created post.
+ */
+export async function postToBluesky(
+  handle: string,
+  appPassword: string,
+  text: string,
+): Promise<string> {
+  const session = await createSession(handle, appPassword);
+
+  const body = {
+    repo: session.did,
+    collection: 'app.bsky.feed.post',
+    record: {
+      $type: 'app.bsky.feed.post',
+      text,
+      createdAt: new Date().toISOString(),
+    },
+  };
+
+  const response = await fetch(
+    'https://bsky.social/xrpc/com.atproto.repo.createRecord',
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${session.accessJwt}`,
+      },
+      body: JSON.stringify(body),
+    },
+  );
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => '');
+    throw new Error(
+      `Bluesky post error: ${response.status} ${response.statusText}${errorText ? ` — ${errorText}` : ''}`,
+    );
+  }
+
+  const result = (await response.json()) as { uri: string };
+  return result.uri;
+}

--- a/src/social/credentials.ts
+++ b/src/social/credentials.ts
@@ -7,6 +7,18 @@ export interface LinkedInCredentials {
   LINKEDIN_PERSON_URN: string;
 }
 
+export interface BlueskyCredentials {
+  BLUESKY_HANDLE: string;
+  BLUESKY_APP_PASSWORD: string;
+}
+
+export interface XCredentials {
+  X_API_KEY: string;
+  X_API_SECRET: string;
+  X_ACCESS_TOKEN: string;
+  X_ACCESS_TOKEN_SECRET: string;
+}
+
 const CREDENTIALS_PATH = join(homedir(), '.config', 'cryyer', 'credentials.json');
 
 /**
@@ -63,4 +75,124 @@ export function saveLinkedInCredentials(creds: LinkedInCredentials): void {
 
 export function getCredentialsPath(): string {
   return CREDENTIALS_PATH;
+}
+
+/**
+ * Load Bluesky credentials from env vars or ~/.config/cryyer/credentials.json.
+ * Returns null if no credentials are found.
+ */
+export function loadBlueskyCredentials(): BlueskyCredentials | null {
+  const handle = process.env['BLUESKY_HANDLE'];
+  const appPassword = process.env['BLUESKY_APP_PASSWORD'];
+
+  if (handle && appPassword) {
+    return { BLUESKY_HANDLE: handle, BLUESKY_APP_PASSWORD: appPassword };
+  }
+
+  try {
+    const raw = readFileSync(CREDENTIALS_PATH, 'utf-8');
+    const data = JSON.parse(raw) as Record<string, string>;
+    const fileHandle = data['BLUESKY_HANDLE'];
+    const fileAppPassword = data['BLUESKY_APP_PASSWORD'];
+
+    if (fileHandle && fileAppPassword) {
+      return { BLUESKY_HANDLE: fileHandle, BLUESKY_APP_PASSWORD: fileAppPassword };
+    }
+  } catch {
+    // File doesn't exist or is invalid
+  }
+
+  return null;
+}
+
+/**
+ * Save Bluesky credentials to ~/.config/cryyer/credentials.json.
+ * Merges with any existing data in the file.
+ */
+export function saveBlueskyCredentials(creds: BlueskyCredentials): void {
+  const dir = dirname(CREDENTIALS_PATH);
+  mkdirSync(dir, { recursive: true });
+
+  let existing: Record<string, string> = {};
+  try {
+    existing = JSON.parse(readFileSync(CREDENTIALS_PATH, 'utf-8')) as Record<string, string>;
+  } catch {
+    // No existing file
+  }
+
+  const merged = {
+    ...existing,
+    BLUESKY_HANDLE: creds.BLUESKY_HANDLE,
+    BLUESKY_APP_PASSWORD: creds.BLUESKY_APP_PASSWORD,
+  };
+
+  writeFileSync(CREDENTIALS_PATH, JSON.stringify(merged, null, 2) + '\n', 'utf-8');
+}
+
+/**
+ * Load X (Twitter) credentials from env vars or ~/.config/cryyer/credentials.json.
+ * Returns null if no credentials are found.
+ */
+export function loadXCredentials(): XCredentials | null {
+  const apiKey = process.env['X_API_KEY'];
+  const apiSecret = process.env['X_API_SECRET'];
+  const accessToken = process.env['X_ACCESS_TOKEN'];
+  const accessTokenSecret = process.env['X_ACCESS_TOKEN_SECRET'];
+
+  if (apiKey && apiSecret && accessToken && accessTokenSecret) {
+    return {
+      X_API_KEY: apiKey,
+      X_API_SECRET: apiSecret,
+      X_ACCESS_TOKEN: accessToken,
+      X_ACCESS_TOKEN_SECRET: accessTokenSecret,
+    };
+  }
+
+  try {
+    const raw = readFileSync(CREDENTIALS_PATH, 'utf-8');
+    const data = JSON.parse(raw) as Record<string, string>;
+    const fileApiKey = data['X_API_KEY'];
+    const fileApiSecret = data['X_API_SECRET'];
+    const fileAccessToken = data['X_ACCESS_TOKEN'];
+    const fileAccessTokenSecret = data['X_ACCESS_TOKEN_SECRET'];
+
+    if (fileApiKey && fileApiSecret && fileAccessToken && fileAccessTokenSecret) {
+      return {
+        X_API_KEY: fileApiKey,
+        X_API_SECRET: fileApiSecret,
+        X_ACCESS_TOKEN: fileAccessToken,
+        X_ACCESS_TOKEN_SECRET: fileAccessTokenSecret,
+      };
+    }
+  } catch {
+    // File doesn't exist or is invalid
+  }
+
+  return null;
+}
+
+/**
+ * Save X (Twitter) credentials to ~/.config/cryyer/credentials.json.
+ * Merges with any existing data in the file.
+ */
+export function saveXCredentials(creds: XCredentials): void {
+  const dir = dirname(CREDENTIALS_PATH);
+  mkdirSync(dir, { recursive: true });
+
+  let existing: Record<string, string> = {};
+  try {
+    existing = JSON.parse(readFileSync(CREDENTIALS_PATH, 'utf-8')) as Record<string, string>;
+  } catch {
+    // No existing file
+  }
+
+  const merged = {
+    ...existing,
+    X_API_KEY: creds.X_API_KEY,
+    X_API_SECRET: creds.X_API_SECRET,
+    X_ACCESS_TOKEN: creds.X_ACCESS_TOKEN,
+    X_ACCESS_TOKEN_SECRET: creds.X_ACCESS_TOKEN_SECRET,
+  };
+
+  writeFileSync(CREDENTIALS_PATH, JSON.stringify(merged, null, 2) + '\n', 'utf-8');
 }

--- a/src/social/send.ts
+++ b/src/social/send.ts
@@ -1,7 +1,13 @@
 import { fileURLToPath } from 'url';
 import { readSocialDraft } from './draft-file.js';
 import { postToLinkedIn } from './linkedin-provider.js';
-import { loadLinkedInCredentials } from './credentials.js';
+import { postToBluesky } from './bluesky-provider.js';
+import { postToX } from './x-provider.js';
+import {
+  loadLinkedInCredentials,
+  loadBlueskyCredentials,
+  loadXCredentials,
+} from './credentials.js';
 
 export function parseArgv(argv: string[]): {
   draftPath: string;
@@ -20,7 +26,7 @@ export function parseArgv(argv: string[]): {
     } else if (args[i] === '--config-dir' && args[i + 1]) {
       configDir = args[i + 1];
       i++;
-    } else if (!args[i].startsWith('-') && !draftPath) {
+    } else if (!args[i]!.startsWith('-') && !draftPath) {
       draftPath = args[i];
     }
   }
@@ -39,13 +45,10 @@ export async function main(): Promise<void> {
 
   const draft = readSocialDraft(draftPath);
 
-  // Load LinkedIn credentials (env vars take precedence over config file)
-  const creds = loadLinkedInCredentials();
-  if (!creds && !dryRun) {
-    throw new Error(
-      'Missing LinkedIn credentials. Run "cryyer auth linkedin" or set LINKEDIN_ACCESS_TOKEN and LINKEDIN_PERSON_URN env vars.',
-    );
-  }
+  // Load credentials for all platforms (env vars take precedence over config file)
+  const linkedInCreds = loadLinkedInCredentials();
+  const blueskyCreds = loadBlueskyCredentials();
+  const xCreds = loadXCredentials();
 
   let posted = 0;
   let skipped = 0;
@@ -61,12 +64,51 @@ export async function main(): Promise<void> {
     }
 
     if (platformId === 'linkedin') {
+      if (!linkedInCreds) {
+        console.warn(
+          '  Skipping linkedin: no credentials configured. Set LINKEDIN_ACCESS_TOKEN and LINKEDIN_PERSON_URN env vars or run "cryyer auth linkedin".',
+        );
+        skipped++;
+        continue;
+      }
       const urn = await postToLinkedIn(
-        creds!.LINKEDIN_ACCESS_TOKEN,
-        creds!.LINKEDIN_PERSON_URN,
+        linkedInCreds.LINKEDIN_ACCESS_TOKEN,
+        linkedInCreds.LINKEDIN_PERSON_URN,
         post.text,
       );
       console.log(`  Posted to LinkedIn: ${urn}`);
+      posted++;
+    } else if (platformId === 'bluesky') {
+      if (!blueskyCreds) {
+        console.warn(
+          '  Skipping bluesky: no credentials configured. Set BLUESKY_HANDLE and BLUESKY_APP_PASSWORD env vars.',
+        );
+        skipped++;
+        continue;
+      }
+      const uri = await postToBluesky(
+        blueskyCreds.BLUESKY_HANDLE,
+        blueskyCreds.BLUESKY_APP_PASSWORD,
+        post.text,
+      );
+      console.log(`  Posted to Bluesky: ${uri}`);
+      posted++;
+    } else if (platformId === 'x') {
+      if (!xCreds) {
+        console.warn(
+          '  Skipping x: no credentials configured. Set X_API_KEY, X_API_SECRET, X_ACCESS_TOKEN, and X_ACCESS_TOKEN_SECRET env vars.',
+        );
+        skipped++;
+        continue;
+      }
+      const tweetId = await postToX(
+        xCreds.X_API_KEY,
+        xCreds.X_API_SECRET,
+        xCreds.X_ACCESS_TOKEN,
+        xCreds.X_ACCESS_TOKEN_SECRET,
+        post.text,
+      );
+      console.log(`  Posted to X: ${tweetId}`);
       posted++;
     } else {
       console.warn(`  Skipping ${platformId}: direct posting not yet supported`);

--- a/src/social/x-provider.ts
+++ b/src/social/x-provider.ts
@@ -1,0 +1,108 @@
+import { createHmac, randomBytes } from 'crypto';
+
+/**
+ * Percent-encode a string per RFC 3986 (required for OAuth 1.0a).
+ */
+function percentEncode(str: string): string {
+  return encodeURIComponent(str).replace(
+    /[!'()*]/g,
+    (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`,
+  );
+}
+
+/**
+ * Build the OAuth 1.0a Authorization header for a request.
+ */
+function buildOAuthHeader(
+  method: string,
+  url: string,
+  apiKey: string,
+  apiSecret: string,
+  accessToken: string,
+  accessTokenSecret: string,
+): string {
+  const timestamp = Math.floor(Date.now() / 1000).toString();
+  const nonce = randomBytes(16).toString('hex');
+
+  const oauthParams: Record<string, string> = {
+    oauth_consumer_key: apiKey,
+    oauth_nonce: nonce,
+    oauth_signature_method: 'HMAC-SHA1',
+    oauth_timestamp: timestamp,
+    oauth_token: accessToken,
+    oauth_version: '1.0',
+  };
+
+  // Build the parameter string (sorted by key)
+  const paramString = Object.keys(oauthParams)
+    .sort()
+    .map((k) => `${percentEncode(k)}=${percentEncode(oauthParams[k]!)}`)
+    .join('&');
+
+  // Build the signature base string
+  const signatureBase = [
+    method.toUpperCase(),
+    percentEncode(url),
+    percentEncode(paramString),
+  ].join('&');
+
+  // Build the signing key
+  const signingKey = `${percentEncode(apiSecret)}&${percentEncode(accessTokenSecret)}`;
+
+  // Generate HMAC-SHA1 signature
+  const signature = createHmac('sha1', signingKey)
+    .update(signatureBase)
+    .digest('base64');
+
+  oauthParams['oauth_signature'] = signature;
+
+  // Build the Authorization header value
+  const headerValue = Object.keys(oauthParams)
+    .sort()
+    .map((k) => `${percentEncode(k)}="${percentEncode(oauthParams[k]!)}"`)
+    .join(', ');
+
+  return `OAuth ${headerValue}`;
+}
+
+/**
+ * Post a tweet to X (Twitter) using OAuth 1.0a authentication.
+ * Returns the tweet ID.
+ */
+export async function postToX(
+  apiKey: string,
+  apiSecret: string,
+  accessToken: string,
+  accessTokenSecret: string,
+  text: string,
+): Promise<string> {
+  const url = 'https://api.twitter.com/2/tweets';
+
+  const authHeader = buildOAuthHeader(
+    'POST',
+    url,
+    apiKey,
+    apiSecret,
+    accessToken,
+    accessTokenSecret,
+  );
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: authHeader,
+    },
+    body: JSON.stringify({ text }),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => '');
+    throw new Error(
+      `X API error: ${response.status} ${response.statusText}${errorText ? ` — ${errorText}` : ''}`,
+    );
+  }
+
+  const result = (await response.json()) as { data: { id: string } };
+  return result.data.id;
+}


### PR DESCRIPTION
## Summary

- Add `bluesky-provider.ts` using AT Protocol (handle + app password authentication, no OAuth needed)
- Add `x-provider.ts` using OAuth 1.0a with HMAC-SHA1 signature generation from scratch (no external dependencies)
- Update `send.ts` to route posts to LinkedIn, Bluesky, and X based on platform ID, gracefully skipping platforms with no credentials configured
- Update `credentials.ts` with load/save helpers for Bluesky (`BLUESKY_HANDLE`, `BLUESKY_APP_PASSWORD`) and X (`X_API_KEY`, `X_API_SECRET`, `X_ACCESS_TOKEN`, `X_ACCESS_TOKEN_SECRET`) credentials

## Test plan

- [ ] Set `BLUESKY_HANDLE` and `BLUESKY_APP_PASSWORD` env vars, run `cryyer social send` with a draft containing a bluesky post
- [ ] Set X env vars (`X_API_KEY`, `X_API_SECRET`, `X_ACCESS_TOKEN`, `X_ACCESS_TOKEN_SECRET`), run with an x-platform draft
- [ ] Verify `--dry-run` still prints all platform posts without making API calls
- [ ] Verify missing credentials produce a warning and skip (not a crash)
- [ ] Verify LinkedIn posting still works unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)